### PR TITLE
Add `showResponsiveLineNumbers` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ I do realize that javascript styles are not for everyone, so you can optionally 
 - `codeTagProps` - props that will be spread into the `<code>` tag that is the direct parent of the highlighted code elements. Useful for styling/assigning classNames.
 - `useInlineStyles` - if this prop is passed in as false, react syntax highlighter will not add style objects to elements, and will instead append classNames. You can then style the code block by using one of the CSS files provided by highlight.js.
 - `showLineNumbers` - if this is enabled line numbers will be shown next to the code block.
-- `startingLineNumber` - if `showLineNumbers` is enabled the line numbering will start from here.
+- `showResponsiveLineNumbers` - if this is enabled line numbers will be shown next to the code block using CSS pseudo-element and (experimental) counters to ensure line numbers are consistent with wrapping.
+- `startingLineNumber` - if `showLineNumbers` or `showResponsiveLineNumbers` is enabled the line numbering will start from here.
 - `lineNumberContainerStyle` - the line numbers container default to appearing to the left with 10px of right padding. You can use this to override those styles.
 - `lineNumberStyle` - inline style to be passed to the span wrapping each number. Can be either an object or a function that receives current line number as argument and returns style object.
 - `wrapLines` - a boolean value that determines whether or not each line of code should be wrapped in a parent element. defaults to false, when false one can not take action on an element on the line level. You can see an example of what this enables <a href="https://conorhastings.github.io/react-syntax-highlighter/demo/diff.html">here</a>

--- a/__tests__/__snapshots__/light-async.js.snap
+++ b/__tests__/__snapshots__/light-async.js.snap
@@ -50,7 +50,14 @@ exports[`SyntaxHighlighter render as text if language doesnt exist 1`] = `
       }
     }
   >
-    print('hello')
+    print(
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+      'hello'
+    </span>
+    )
   </code>
 </pre>
 `;

--- a/__tests__/light-async.js
+++ b/__tests__/light-async.js
@@ -38,7 +38,7 @@ class Expire extends React.Component {
 
 test('SyntaxHighlighter render as text if language doesnt exist', () => {
   const tree = renderer.create(
-    <SyntaxHighlighter language="nonexistinglanguage" style={prism}>
+    <SyntaxHighlighter language="ruby" style={prism}>
       {"print('hello')"}
     </SyntaxHighlighter>
   );

--- a/__tests__/prism-async-light.js
+++ b/__tests__/prism-async-light.js
@@ -38,7 +38,7 @@ class Expire extends React.Component {
 test('SyntaxHighlighter should just render text if syntax is not registered', () => {
   const tree = renderer
     .create(
-      <SyntaxHighlighter language="nonexistinglanguage" style={prism}>
+      <SyntaxHighlighter language="ruby" style={prism}>
         {"print('hello')"}
       </SyntaxHighlighter>
     )

--- a/demo/index.js
+++ b/demo/index.js
@@ -121,7 +121,8 @@ function createElement({ node, style, useInlineStyles, key }) {
       selected: 'tomorrow-night-eighties',
       style: require('../src/styles/hljs/tomorrow-night-eighties').default,
       code: initialCodeString,
-      showLineNumbers: false
+      showLineNumbers: false,
+      showResponsiveLineNumbers: false
     };
   }
   render() {
@@ -165,6 +166,22 @@ function createElement({ node, style, useInlineStyles, key }) {
             id="showLineNumbers"
           />
         </div>
+        <div style={{ paddingTop: '10px', fontSize: 16, color: 'aliceblue' }}>
+          <label htmlFor="showResponsiveLineNumbers">
+            Show Responsive Line Numbers:
+          </label>
+          <input
+            type="checkbox"
+            checked={this.state.showResponsiveLineNumbers}
+            onChange={() => {
+              this.setState({
+                showResponsiveLineNumbers: !this.state.showResponsiveLineNumbers
+              });
+              console.log(this.state.showResponsiveLineNumbers);
+            }}
+            id="showResponsiveLineNumbers"
+          />
+        </div>
         <div style={{ paddingTop: 20, display: 'flex' }}>
           <textarea
             style={{ flex: 1, marginTop: 11 }}
@@ -177,6 +194,7 @@ function createElement({ node, style, useInlineStyles, key }) {
             <SyntaxHighlighter
               style={this.state.style}
               showLineNumbers={this.state.showLineNumbers}
+              showResponsiveLineNumbers={this.state.showResponsiveLineNumbers}
               wrapLines={true}
               lineProps={lineNumber => ({
                 style: { display: 'block', cursor: 'pointer' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,7 +920,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1334,7 +1334,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -1367,7 +1367,7 @@
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
@@ -1414,7 +1414,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1464,7 +1464,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
@@ -2225,7 +2225,7 @@
     },
     "callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
@@ -2381,7 +2381,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2696,7 +2696,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -2965,7 +2965,7 @@
       "dependencies": {
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         },
@@ -3072,7 +3072,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -3081,7 +3081,7 @@
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
           "dev": true
         }
@@ -3134,7 +3134,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -3189,7 +3189,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -3284,7 +3284,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
@@ -3463,7 +3463,7 @@
     },
     "encoding": {
       "version": "0.1.12",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "dev": true,
       "requires": {
@@ -3599,7 +3599,7 @@
     },
     "esprima": {
       "version": "2.7.3",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
     },
@@ -3620,7 +3620,7 @@
     },
     "esutils": {
       "version": "2.0.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
@@ -3964,7 +3964,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
           "dev": true
         }
@@ -4110,7 +4110,7 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
@@ -5022,9 +5022,9 @@
       }
     },
     "highlight.js": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
+      "version": "9.15.10",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -5402,7 +5402,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -5412,7 +5412,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
@@ -5741,7 +5741,7 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
@@ -5765,7 +5765,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
@@ -5783,7 +5783,7 @@
     },
     "isarray": {
       "version": "1.0.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
@@ -5801,7 +5801,7 @@
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "dev": true,
       "requires": {
@@ -5811,7 +5811,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
@@ -6254,7 +6254,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -6862,7 +6862,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
@@ -6874,7 +6874,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -7081,7 +7081,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -7171,7 +7171,7 @@
       "dependencies": {
         "json5": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
           "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
           "dev": true
         }
@@ -7323,12 +7323,19 @@
       }
     },
     "lowlight": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
-      "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.12.1.tgz",
+      "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
       "requires": {
         "fault": "^1.0.2",
-        "highlight.js": "~9.13.0"
+        "highlight.js": "~9.15.0"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "9.15.10",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.10.tgz",
+          "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw=="
+        }
       }
     },
     "lru-cache": {
@@ -7560,7 +7567,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": false,
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -7605,7 +7612,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": false,
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -7855,7 +7862,7 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
@@ -7992,7 +7999,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
@@ -8082,7 +8089,7 @@
     },
     "p-is-promise": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true
     },
@@ -8279,13 +8286,13 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
@@ -8344,7 +8351,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }
@@ -8376,7 +8383,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -8646,7 +8653,7 @@
         },
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         },
@@ -8674,7 +8681,7 @@
         },
         "regjsgen": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
           "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
           "dev": true
         },
@@ -8718,7 +8725,7 @@
         },
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         },
@@ -8746,7 +8753,7 @@
         },
         "regjsgen": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
           "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
           "dev": true
         },
@@ -9349,7 +9356,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -9499,7 +9506,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -9519,7 +9526,7 @@
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
@@ -10314,7 +10321,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -10524,7 +10531,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -11446,7 +11453,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
@@ -11929,7 +11936,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -11961,7 +11968,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -11999,7 +12006,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "sideEffects": false,
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "highlight.js": "~9.13.0",
-    "lowlight": "~1.11.0",
+    "highlight.js": "~9.15.1",
+    "lowlight": "1.12.1",
     "prismjs": "^1.8.4",
     "refractor": "^2.4.1"
   },

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -191,6 +191,7 @@ export default function(defaultAstGenerator, defaultStyle) {
     useInlineStyles = true,
     showLineNumbers = false,
     startingLineNumber = 1,
+    showResponsiveLineNumbers = false,
     lineNumberContainerStyle,
     lineNumberStyle,
     wrapLines,
@@ -204,15 +205,51 @@ export default function(defaultAstGenerator, defaultStyle) {
   }) {
     astGenerator = astGenerator || defaultAstGenerator;
 
-    const lineNumbers = showLineNumbers ? (
-      <LineNumbers
-        containerStyle={lineNumberContainerStyle}
-        codeStyle={codeTagProps.style || {}}
-        numberStyle={lineNumberStyle}
-        startingLineNumber={startingLineNumber}
-        codeString={code}
-      />
-    ) : null;
+    const lineNumbers =
+      showLineNumbers && !showResponsiveLineNumbers ? (
+        <LineNumbers
+          containerStyle={lineNumberContainerStyle}
+          codeStyle={codeTagProps.style || {}}
+          numberStyle={lineNumberStyle}
+          startingLineNumber={startingLineNumber}
+          codeString={code}
+        />
+      ) : showResponsiveLineNumbers ? (
+        <style>{`
+        .code-line {
+          counter-increment: line;
+          position: relative;
+          display: block;
+          margin-left: 1.5rem;
+        }
+      
+        .code-line:before {
+          content: counter(line);
+          position: absolute;
+          margin-left: -1.5rem;
+        }
+      `}</style>
+      ) : null;
+
+    if (showResponsiveLineNumbers) {
+      wrapLines = true;
+
+      codeTagProps.style = {
+        ...codeTagProps.style,
+        counterReset: 'line'
+      };
+
+      const lineClassName = `code-line ${lineProps.className || ''}`;
+      if (typeof lineProps === 'function') {
+        const origLinePropsFn = lineProps.bind({});
+        lineProps = num => ({
+          ...origLinePropsFn(num),
+          className: lineClassName
+        });
+      } else {
+        lineProps.className = lineClassName;
+      }
+    }
 
     const defaultPreStyle = style.hljs ||
       style['pre[class*="language-"]'] || { backgroundColor: '#fff' };

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -236,7 +236,7 @@ export default function(defaultAstGenerator, defaultStyle) {
 
       codeTagProps.style = {
         ...codeTagProps.style,
-        counterReset: 'line'
+        counterReset: `line ${startingLineNumber - 1}`
       };
 
       const lineClassName = `code-line ${lineProps.className || ''}`;

--- a/src/styles/hljs/github-gist.js
+++ b/src/styles/hljs/github-gist.js
@@ -12,9 +12,6 @@ export default {
     "hljs-meta": {
         "color": "#969896"
     },
-    "hljs-string": {
-        "color": "#df5000"
-    },
     "hljs-variable": {
         "color": "#df5000"
     },
@@ -31,13 +28,13 @@ export default {
         "color": "#df5000"
     },
     "hljs-keyword": {
-        "color": "#a71d5d"
+        "color": "#d73a49"
     },
     "hljs-selector-tag": {
-        "color": "#a71d5d"
+        "color": "#d73a49"
     },
     "hljs-type": {
-        "color": "#a71d5d"
+        "color": "#d73a49"
     },
     "hljs-literal": {
         "color": "#0086b3"
@@ -61,22 +58,22 @@ export default {
         "color": "#333333"
     },
     "hljs-title": {
-        "color": "#795da3"
+        "color": "#6f42c1"
     },
     "hljs-attr": {
-        "color": "#795da3"
+        "color": "#6f42c1"
     },
     "hljs-selector-id": {
-        "color": "#795da3"
+        "color": "#6f42c1"
     },
     "hljs-selector-class": {
-        "color": "#795da3"
+        "color": "#6f42c1"
     },
     "hljs-selector-attr": {
-        "color": "#795da3"
+        "color": "#6f42c1"
     },
     "hljs-selector-pseudo": {
-        "color": "#795da3"
+        "color": "#6f42c1"
     },
     "hljs-addition": {
         "color": "#55a532",
@@ -88,5 +85,11 @@ export default {
     },
     "hljs-link": {
         "textDecoration": "underline"
+    },
+    "hljs-number": {
+        "color": "#005cc5"
+    },
+    "hljs-string": {
+        "color": "#032f62"
     }
 }

--- a/src/styles/hljs/school-book.js
+++ b/src/styles/hljs/school-book.js
@@ -5,12 +5,10 @@ export default {
         "padding": "15px 0.5em 0.5em 30px",
         "fontSize": "11px",
         "lineHeight": "16px",
-        "color": "#3e5915"
-    },
-    "re": {
         "background": "#f6f6ae url(./school-book.png)",
         "borderTop": "solid 2px #d2e8b9",
-        "borderBottom": "solid 1px #d2e8b9"
+        "borderBottom": "solid 1px #d2e8b9",
+        "color": "#3e5915"
     },
     "hljs-keyword": {
         "color": "#005599",

--- a/src/styles/hljs/xt256.js
+++ b/src/styles/hljs/xt256.js
@@ -4,7 +4,7 @@ export default {
         "overflowX": "auto",
         "color": "#eaeaea",
         "background": "#000",
-        "padding": "0.5"
+        "padding": "0.5em"
     },
     "hljs-subst": {
         "color": "#eaeaea"


### PR DESCRIPTION
Resolves #219 

A few notes:
- Created a new `showResponsiveLineNumbers` as to not introduce any breaking changes to the existing `showLineNumbers` property.
- The new prop takes precedence over the existing line number functionality and should inherit existing styling and `lineProps` without incidence. 
- This uses CSS counters which may have [experimental support](https://developer.mozilla.org/en-US/docs/Web/CSS/counter-increment#Browser_compatibility).
- Sets `wrapLines = true` by default as they are required for the `.code-line` class to be applied.
- Styling couldn't be totally inlined as CSS pseudo-elements are used to display the number preceding the line.