### PR TITLE
fix #285: incorrect syntax highlighting for mutli-line comments

### DIFF
--- a/__tests__/__snapshots__/light-async.js.snap
+++ b/__tests__/__snapshots__/light-async.js.snap
@@ -736,26 +736,76 @@ exports[`SyntaxHighlighter renders fortran highlighted text 1`] = `
       'S FORMULA WE CALCULATE THE
 
     </span>
-                C AREA OF THE TRIANGLE
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                  C AREA OF THE TRIANGLE
 
-                799 S = FLOATF (IA + IB + IC) / 2.0
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                  799 S = FLOATF (IA + IB + IC) / 2.0
 
-                    AREA = SQRTF( S * (S - FLOATF(IA)) * (S - FLOATF(IB)) *
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      AREA = SQRTF( S * (S - FLOATF(IA)) * (S - FLOATF(IB)) *
 
-                    +     (S - FLOATF(IC)))
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      +     (S - FLOATF(IC)))
 
-                    WRITE OUTPUT TAPE 6, 601, IA, IB, IC, AREA
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      WRITE OUTPUT TAPE 6, 601, IA, IB, IC, AREA
 
-                601 FORMAT (4H A= ,I5,5H  B= ,I5,5H  C= ,I5,8H  AREA= ,F10.2,
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                  601 FORMAT (4H A= ,I5,5H  B= ,I5,5H  C= ,I5,8H  AREA= ,F10.2,
 
-                    +        13H SQUARE UNITS)
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      +        13H SQUARE UNITS)
 
-                    STOP
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      STOP
 
-                    END
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      END
 
-                       
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                         
 
+    </span>
   </code>
 </pre>
 `;
@@ -1533,26 +1583,76 @@ exports[`SyntaxHighlighter renders text while language loads 1`] = `
       'S FORMULA WE CALCULATE THE
 
     </span>
-                C AREA OF THE TRIANGLE
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                  C AREA OF THE TRIANGLE
 
-                799 S = FLOATF (IA + IB + IC) / 2.0
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                  799 S = FLOATF (IA + IB + IC) / 2.0
 
-                    AREA = SQRTF( S * (S - FLOATF(IA)) * (S - FLOATF(IB)) *
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      AREA = SQRTF( S * (S - FLOATF(IA)) * (S - FLOATF(IB)) *
 
-                    +     (S - FLOATF(IC)))
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      +     (S - FLOATF(IC)))
 
-                    WRITE OUTPUT TAPE 6, 601, IA, IB, IC, AREA
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      WRITE OUTPUT TAPE 6, 601, IA, IB, IC, AREA
 
-                601 FORMAT (4H A= ,I5,5H  B= ,I5,5H  C= ,I5,8H  AREA= ,F10.2,
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                  601 FORMAT (4H A= ,I5,5H  B= ,I5,5H  C= ,I5,8H  AREA= ,F10.2,
 
-                    +        13H SQUARE UNITS)
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      +        13H SQUARE UNITS)
 
-                    STOP
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      STOP
 
-                    END
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                      END
 
-                       
+    </span>
+    <span
+      className="hljs-string"
+      style={Object {}}
+    >
+                         
 
+    </span>
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/multiline-comments.js.snap
+++ b/__tests__/__snapshots__/multiline-comments.js.snap
@@ -1,0 +1,174 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Syntaxhighliter correctly renders multi-line comments in arduino language 1`] = `
+<pre
+  style={
+    Object {
+      "background": "#F0F0F0",
+      "color": "#444",
+      "display": "block",
+      "overflowX": "auto",
+      "padding": "0.5em",
+    }
+  }
+>
+  <code>
+    <span
+      style={Object {}}
+    >
+      
+
+    </span>
+    <span
+      style={Object {}}
+    >
+      
+    </span>
+    <span
+      style={
+        Object {
+          "color": "#888888",
+        }
+      }
+    >
+      /* This is a multi-
+
+    </span>
+    <span
+      style={
+        Object {
+          "color": "#888888",
+        }
+      }
+    >
+         line comment. 
+
+    </span>
+    <span
+      style={
+        Object {
+          "color": "#888888",
+        }
+      }
+    >
+      */
+    </span>
+    <span
+      style={Object {}}
+    >
+      
+
+    </span>
+    
+
+    <span
+      style={Object {}}
+    >
+      
+    </span>
+    <span
+      className="hljs-function"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      void
+    </span>
+    <span
+      className="hljs-function"
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="hljs-function"
+      style={
+        Object {
+          "color": "#880000",
+          "fontWeight": "bold",
+        }
+      }
+    >
+      setup
+    </span>
+    <span
+      className="hljs-function hljs-params"
+      style={Object {}}
+    >
+      ()
+    </span>
+    <span
+      className="hljs-function"
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      style={Object {}}
+    >
+      {
+
+    </span>
+    }
+
+    
+
+    <span
+      style={Object {}}
+    >
+      
+    </span>
+    <span
+      className="hljs-function"
+      style={
+        Object {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      void
+    </span>
+    <span
+      className="hljs-function"
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="hljs-function"
+      style={
+        Object {
+          "color": "#880000",
+          "fontWeight": "bold",
+        }
+      }
+    >
+      loop
+    </span>
+    <span
+      className="hljs-function hljs-params"
+      style={Object {}}
+    >
+      ()
+    </span>
+    <span
+      className="hljs-function"
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      style={Object {}}
+    >
+      {
+
+    </span>
+    }
+
+    
+
+  </code>
+</pre>
+`;

--- a/__tests__/multiline-comments.js
+++ b/__tests__/multiline-comments.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import SyntaxHighlighter from '../src';
+
+const code = `
+/* This is a multi-
+   line comment. 
+*/
+
+void setup() {
+}
+
+void loop() {
+}
+`;
+
+test('Syntaxhighliter correctly renders multi-line comments in arduino language', () => {
+  const tree = renderer
+    .create(<SyntaxHighlighter language="arduino">{code}</SyntaxHighlighter>)
+    .toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -175,7 +175,7 @@ function processLines(
   }
 
   function createLine(children, lineNumber, className = []) {
-    return wrapLines
+    return wrapLines || className.length > 0
       ? createWrappedLine(children, lineNumber, className)
       : createUnwrappedLine(children, lineNumber);
   }
@@ -204,7 +204,7 @@ function processLines(
           const line = createLine(children, lineNumber);
           newTree.push(line);
 
-          // if it's neither the first nor the last line
+          // if it's the last line
         } else if (i === splitValue.length - 1) {
           const stringChild =
             tree[index + 1] &&
@@ -227,7 +227,7 @@ function processLines(
             newTree.push(line);
           }
 
-          // if it's the last line
+          // if it's neither the first nor the last line
         } else {
           const children = [newChild];
           const line = createLine(


### PR DESCRIPTION
It seems like the issue was related to calling `createUnwrappedLine` instead of `createWrappedLine` even for lines that had a className set. 

In addition to fixing that, I also fixed two misplaced comments, and created a new test case that fails with the existing code and passes after the fix.

Note that two existing tests broke due to the fix, I updated their snapshots and verified that the new snapshots make sense (it seems like the issue also affected these two test cases).

