### PR TITLE
wrapLongLines + line numbering with wrapped lines

### DIFF
--- a/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
+++ b/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] = `
+exports[`SyntaxHighlighter component passes along code style to non-inline line numbers element 1`] = `
 <pre
   style={
     Object {
@@ -20,20 +20,87 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
       }
     }
   >
-    <span
-      className="comment linenumber react-syntax-highlighter-line-number"
+    <code
       style={
         Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
+          "color": "blue",
+          "float": "left",
+          "paddingRight": "10px",
+          "whiteSpace": "pre",
         }
       }
     >
-      1
-    </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        1
+
+      </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        2
+
+      </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        3
+
+      </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        4
+
+      </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        5
+
+      </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        6
+
+      </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        7
+
+      </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        8
+
+      </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        9
+
+      </span>
+      <span
+        className="react-syntax-highlighter-line-number"
+        style={Object {}}
+      >
+        10
+
+      </span>
+    </code>
     <span
       style={
         Object {
@@ -79,20 +146,6 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
     >
       ;
 
-    </span>
-    <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      2
     </span>
     <span
       style={Object {}}
@@ -143,20 +196,6 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
 
     </span>
     <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      3
-    </span>
-    <span
       style={Object {}}
     >
       
@@ -205,20 +244,6 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
     >
       {
 
-    </span>
-    <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      4
     </span>
     <span
       style={Object {}}
@@ -327,36 +352,8 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
       );
 
     </span>
-    <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      5
-    </span>
     }
 
-    <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      6
-    </span>
     <span
       style={Object {}}
     >
@@ -391,36 +388,8 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
       );
 
     </span>
-    <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      7
-    </span>
     
 
-    <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      8
-    </span>
     <span
       style={Object {}}
     >
@@ -472,20 +441,6 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
 
     </span>
     <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      9
-    </span>
-    <span
       style={Object {}}
     >
         
@@ -519,36 +474,8 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
       ;
 
     </span>
-    <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      10
-    </span>
     }
 
-    <span
-      className="comment linenumber react-syntax-highlighter-line-number"
-      style={
-        Object {
-          "display": "inline-block",
-          "minWidth": "2em",
-          "paddingRight": "1em",
-          "textAlign": "right",
-          "userSelect": "none",
-        }
-      }
-    >
-      11
-    </span>
     
 
   </code>

--- a/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
+++ b/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
@@ -26,7 +26,6 @@ exports[`SyntaxHighlighter component passes along code style to non-inline line 
           "color": "blue",
           "float": "left",
           "paddingRight": "10px",
-          "whiteSpace": "pre",
         }
       }
     >

--- a/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
+++ b/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
@@ -16,89 +16,24 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
     style={
       Object {
         "color": "blue",
+        "whiteSpace": "pre",
       }
     }
   >
-    <code
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
       style={
         Object {
-          "color": "blue",
-          "float": "left",
-          "paddingRight": "10px",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
         }
       }
     >
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        1
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        2
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        3
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        4
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        5
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        6
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        7
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        8
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        9
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        10
-
-      </span>
-    </code>
+      1
+    </span>
     <span
       style={
         Object {
@@ -144,6 +79,20 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
     >
       ;
 
+    </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      2
     </span>
     <span
       style={Object {}}
@@ -194,6 +143,20 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
 
     </span>
     <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      3
+    </span>
+    <span
       style={Object {}}
     >
       
@@ -242,6 +205,20 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
     >
       {
 
+    </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      4
     </span>
     <span
       style={Object {}}
@@ -350,8 +327,36 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
       );
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      5
+    </span>
     }
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      6
+    </span>
     <span
       style={Object {}}
     >
@@ -386,8 +391,36 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
       );
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      7
+    </span>
     
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      8
+    </span>
     <span
       style={Object {}}
     >
@@ -439,6 +472,20 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
 
     </span>
     <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      9
+    </span>
+    <span
       style={Object {}}
     >
         
@@ -472,8 +519,36 @@ exports[`SyntaxHighlighter component passes along code style to LineNumbers 1`] 
       ;
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      10
+    </span>
     }
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      11
+    </span>
     
 
   </code>

--- a/__tests__/__snapshots__/custom-code.js.snap
+++ b/__tests__/__snapshots__/custom-code.js.snap
@@ -12,7 +12,13 @@ exports[`SyntaxHighlighter component renders custom react component where code t
     }
   }
 >
-  <section>
+  <section
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
+  >
     <span
       style={
         Object {
@@ -406,7 +412,13 @@ exports[`SyntaxHighlighter renders div where code tag is by default 1`] = `
     }
   }
 >
-  <div>
+  <div
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
+  >
     <span
       style={
         Object {

--- a/__tests__/__snapshots__/custom-pre.js.snap
+++ b/__tests__/__snapshots__/custom-pre.js.snap
@@ -12,7 +12,13 @@ exports[`SyntaxHighlighter component renders custom react component where pre ta
     }
   }
 >
-  <code>
+  <code
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
+  >
     <span
       style={
         Object {
@@ -406,7 +412,13 @@ exports[`SyntaxHighlighter renders div where pre tag is by default 1`] = `
     }
   }
 >
-  <code>
+  <code
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
+  >
     <span
       style={
         Object {

--- a/__tests__/__snapshots__/light-async.js.snap
+++ b/__tests__/__snapshots__/light-async.js.snap
@@ -54,6 +54,21 @@ exports[`SyntaxHighlighter render as text if language doesnt exist 1`] = `
     }
   >
     <span
+      className="linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "slategray",
+          "display": "inline-block",
+          "minWidth": "1em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      1
+    </span>
+    <span
       style={Object {}}
     >
       print('hello')

--- a/__tests__/__snapshots__/line-numbers.js.snap
+++ b/__tests__/__snapshots__/line-numbers.js.snap
@@ -14,126 +14,27 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
 >
   <code
     className="language-javascript"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
-    <code
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
       style={
         Object {
-          "float": "left",
-          "paddingRight": "10px",
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
         }
       }
     >
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        1
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        2
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        3
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        4
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        5
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        6
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        7
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        8
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        9
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        10
-
-      </span>
-    </code>
+      1
+    </span>
     <span
       style={
         Object {
@@ -179,6 +80,21 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
     >
       ;
 
+    </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      2
     </span>
     <span
       style={Object {}}
@@ -229,6 +145,21 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
 
     </span>
     <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      3
+    </span>
+    <span
       style={Object {}}
     >
       
@@ -277,6 +208,21 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
     >
       {
 
+    </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      4
     </span>
     <span
       style={Object {}}
@@ -385,8 +331,38 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
       );
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      5
+    </span>
     }
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      6
+    </span>
     <span
       style={Object {}}
     >
@@ -421,8 +397,38 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
       );
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      7
+    </span>
     
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      8
+    </span>
     <span
       style={Object {}}
     >
@@ -474,6 +480,21 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
 
     </span>
     <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      9
+    </span>
+    <span
       style={Object {}}
     >
         
@@ -507,8 +528,38 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
       ;
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      10
+    </span>
     }
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      11
+    </span>
     
 
   </code>
@@ -529,6 +580,11 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
 >
   <code
     className="language-javascript"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       className="comment linenumber react-syntax-highlighter-line-number"
@@ -1090,126 +1146,27 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
 >
   <code
     className="language-javascript"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
-    <code
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
       style={
         Object {
-          "float": "left",
-          "paddingRight": "10px",
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
         }
       }
     >
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        1
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        2
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        3
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        4
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        5
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        6
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        7
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        8
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        9
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "color": "red",
-          }
-        }
-      >
-        10
-
-      </span>
-    </code>
+      1
+    </span>
     <span
       style={
         Object {
@@ -1255,6 +1212,21 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
     >
       ;
 
+    </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      2
     </span>
     <span
       style={Object {}}
@@ -1305,6 +1277,21 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
 
     </span>
     <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      3
+    </span>
+    <span
       style={Object {}}
     >
       
@@ -1353,6 +1340,21 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
     >
       {
 
+    </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      4
     </span>
     <span
       style={Object {}}
@@ -1461,8 +1463,38 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
       );
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      5
+    </span>
     }
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      6
+    </span>
     <span
       style={Object {}}
     >
@@ -1497,8 +1529,38 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
       );
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      7
+    </span>
     
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      8
+    </span>
     <span
       style={Object {}}
     >
@@ -1550,6 +1612,21 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
 
     </span>
     <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      9
+    </span>
+    <span
       style={Object {}}
     >
         
@@ -1583,8 +1660,38 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
       ;
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      10
+    </span>
     }
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "red",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      11
+    </span>
     
 
   </code>
@@ -1605,86 +1712,26 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
 >
   <code
     className="language-javascript"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
-    <code
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
       style={
         Object {
-          "float": "left",
-          "paddingRight": "10px",
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
         }
       }
     >
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        1
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        2
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        3
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        4
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        5
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        6
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        7
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        8
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        9
-
-      </span>
-      <span
-        className="react-syntax-highlighter-line-number"
-        style={Object {}}
-      >
-        10
-
-      </span>
-    </code>
+      1
+    </span>
     <span
       style={
         Object {
@@ -1730,6 +1777,20 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
     >
       ;
 
+    </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      2
     </span>
     <span
       style={Object {}}
@@ -1780,6 +1841,20 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
 
     </span>
     <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      3
+    </span>
+    <span
       style={Object {}}
     >
       
@@ -1828,6 +1903,20 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
     >
       {
 
+    </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      4
     </span>
     <span
       style={Object {}}
@@ -1936,8 +2025,36 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       );
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      5
+    </span>
     }
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      6
+    </span>
     <span
       style={Object {}}
     >
@@ -1972,8 +2089,36 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       );
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      7
+    </span>
     
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      8
+    </span>
     <span
       style={Object {}}
     >
@@ -2025,6 +2170,20 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
 
     </span>
     <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      9
+    </span>
+    <span
       style={Object {}}
     >
         
@@ -2058,8 +2217,36 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       ;
 
     </span>
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      10
+    </span>
     }
 
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "2em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      11
+    </span>
     
 
   </code>

--- a/__tests__/__snapshots__/multiline-comments.js.snap
+++ b/__tests__/__snapshots__/multiline-comments.js.snap
@@ -14,6 +14,11 @@ exports[`Syntaxhighliter correctly renders multi-line comments in arduino langua
 >
   <code
     className="language-arduino"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       style={Object {}}

--- a/__tests__/__snapshots__/no-inline.js.snap
+++ b/__tests__/__snapshots__/no-inline.js.snap
@@ -7,6 +7,11 @@ exports[`SyntaxHighlighter component renders correctly without inline styles whe
 >
   <code
     className="language-javascript"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       className="hljs-keyword"

--- a/__tests__/__snapshots__/no-language.js.snap
+++ b/__tests__/__snapshots__/no-language.js.snap
@@ -12,7 +12,13 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
     }
   }
 >
-  <code>
+  <code
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
+  >
     <span
       style={
         Object {

--- a/__tests__/__snapshots__/prism-async-light.js.snap
+++ b/__tests__/__snapshots__/prism-async-light.js.snap
@@ -130,6 +130,21 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
     }
   >
     <span
+      className="linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "slategray",
+          "display": "inline-block",
+          "minWidth": "1em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      1
+    </span>
+    <span
       style={Object {}}
     >
       print('hello')

--- a/__tests__/__snapshots__/prism-async.js.snap
+++ b/__tests__/__snapshots__/prism-async.js.snap
@@ -130,6 +130,21 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
     }
   >
     <span
+      className="linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "slategray",
+          "display": "inline-block",
+          "minWidth": "1em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      1
+    </span>
+    <span
       className="token"
       style={
         Object {
@@ -1360,6 +1375,21 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
     >
       
 
+    </span>
+    <span
+      className="linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "slategray",
+          "display": "inline-block",
+          "minWidth": "3em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      19
     </span>
     <span
       style={Object {}}

--- a/__tests__/__snapshots__/prism-light.js.snap
+++ b/__tests__/__snapshots__/prism-light.js.snap
@@ -1189,6 +1189,21 @@ exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
 
     </span>
     <span
+      className="linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "slategray",
+          "display": "inline-block",
+          "minWidth": "3em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      19
+    </span>
+    <span
       style={Object {}}
     >
       
@@ -1260,6 +1275,21 @@ exports[`SyntaxHighlighter should just render text if syntax is not registered 1
       }
     }
   >
+    <span
+      className="linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "color": "slategray",
+          "display": "inline-block",
+          "minWidth": "1em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      1
+    </span>
     <span
       className="token"
       style={

--- a/__tests__/__snapshots__/render-plain-string.js.snap
+++ b/__tests__/__snapshots__/render-plain-string.js.snap
@@ -8,7 +8,27 @@ exports[`SyntaxHighlighter renders childre unadultered when no language disocver
     }
   }
 >
-  <code>
+  <code
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
+  >
+    <span
+      className="comment linenumber react-syntax-highlighter-line-number"
+      style={
+        Object {
+          "display": "inline-block",
+          "minWidth": "1em",
+          "paddingRight": "1em",
+          "textAlign": "right",
+          "userSelect": "none",
+        }
+      }
+    >
+      1
+    </span>
     <span
       style={Object {}}
     >

--- a/__tests__/__snapshots__/render.js.snap
+++ b/__tests__/__snapshots__/render.js.snap
@@ -14,6 +14,11 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
 >
   <code
     className="language-javascript"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       style={

--- a/__tests__/__snapshots__/text-language.js.snap
+++ b/__tests__/__snapshots__/text-language.js.snap
@@ -14,6 +14,11 @@ exports[`SyntaxHighlighter component renders monospace text when text is passed 
 >
   <code
     className="language-text"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       style={Object {}}

--- a/__tests__/__snapshots__/unknown-language.js.snap
+++ b/__tests__/__snapshots__/unknown-language.js.snap
@@ -14,6 +14,11 @@ exports[`SyntaxHighlighter component renders correctly by falling back to highli
 >
   <code
     className="language-j"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       style={

--- a/__tests__/__snapshots__/wrap-lines.js.snap
+++ b/__tests__/__snapshots__/wrap-lines.js.snap
@@ -14,6 +14,11 @@ exports[`SyntaxHighlighter allows lineProps as an object 1`] = `
 >
   <code
     className="language-javascript"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       style={
@@ -498,6 +503,11 @@ exports[`SyntaxHighlighter allows lineProps as function 1`] = `
 >
   <code
     className="language-javascript"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       style={
@@ -982,6 +992,11 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
 >
   <code
     className="language-javascript"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       style={Object {}}
@@ -1422,6 +1437,11 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
 >
   <code
     className="language-java"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
   >
     <span
       style={
@@ -2184,6 +2204,20 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
         }
       }
     >
+      <span
+        className="comment linenumber react-syntax-highlighter-line-number"
+        style={
+          Object {
+            "display": "inline-block",
+            "minWidth": "2em",
+            "paddingRight": "1em",
+            "textAlign": "right",
+            "userSelect": "none",
+          }
+        }
+      >
+        25
+      </span>
       <span
         style={Object {}}
       >

--- a/__tests__/code-style-passed-to-line-numbers.js
+++ b/__tests__/code-style-passed-to-line-numbers.js
@@ -14,12 +14,13 @@ function itIs() {
 }
 `;
 
-test('SyntaxHighlighter component passes along code style to LineNumbers', () => {
+test('SyntaxHighlighter component passes along code style to non-inline line numbers element', () => {
   const tree = renderer
     .create(
       <SyntaxHighlighter
         codeTagProps={{ style: { color: 'blue' } }}
         showLineNumbers={true}
+        showInlineLineNumbers={false}
       >
         {code}
       </SyntaxHighlighter>

--- a/demo/index.js
+++ b/demo/index.js
@@ -21,6 +21,8 @@ function createClassNameString(classNames) {
   return classNames.join(' ');
 }
 
+// this comment is here to demonstrate an extremely long line length, well beyond what you should probably allow in your own code, though sometimes you'll be highlighting code you can't refactor, which is unfortunate but should be handled gracefully
+
 function createChildren(style, useInlineStyles) {
   let childrenCount = 0;
   return children => {
@@ -43,10 +45,8 @@ function createElement({ node, style, useInlineStyles, key }) {
     const childrenCreator = createChildren(style, useInlineStyles);
     const props = (
       useInlineStyles
-      ?
-      { style: createStyleObject(properties.className, style) }
-      :
-      { className: createClassNameString(properties.className) }
+      ? { style: createStyleObject(properties.className, style) }
+      : { className: createClassNameString(properties.className) }
     );
     const children = childrenCreator(node.children);
     return <TagName key={key} {...props}>{children}</TagName>;

--- a/demo/index.js
+++ b/demo/index.js
@@ -58,7 +58,8 @@ function createElement({ node, style, useInlineStyles, key }) {
       selectedStyle: availableStyles[0],
       style: require(`../src/styles/hljs/${availableStyles[0]}`).default,
       code: initialCodeString,
-      showLineNumbers: false
+      showLineNumbers: false,
+      wrapLongLines: false
     };
   }
   render() {
@@ -122,6 +123,24 @@ function createElement({ node, style, useInlineStyles, key }) {
                 <span className="label__text">Show line numbers</span>
               </label>
             </div>
+
+            <div className="options__option options__option--wrap-long-lines">
+              <label htmlFor="wrapLongLines" className="option__label">
+                <input
+                  type="checkbox"
+                  className="option__checkbox"
+                  checked={this.state.wrapLongLines}
+                  onChange={() =>
+                    this.setState({
+                      wrapLongLines: !this.state.wrapLongLines
+                    })
+                  }
+                  id="wrapLongLines"
+                />
+
+                <span className="label__text">Wrap long lines</span>
+              </label>
+            </div>
           </aside>
 
           <article className="example__container">
@@ -137,6 +156,7 @@ function createElement({ node, style, useInlineStyles, key }) {
               language={this.state.language}
               style={this.state.style}
               showLineNumbers={this.state.showLineNumbers}
+              wrapLongLines={this.state.wrapLongLines}
               wrapLines={true}
               lineProps={lineNumber => ({
                 style: { display: 'block', cursor: 'pointer' },

--- a/demo/prism-async-light.js
+++ b/demo/prism-async-light.js
@@ -75,6 +75,7 @@ function createElement({ node, style, useInlineStyles, key }) {
     this.state = {
       code: initialCodeString,
       showLineNumbers: false,
+      wrapLongLines: false,
       style: 'atom-dark',
       styleSrc: require('../src/styles/prism/atom-dark').default,
       language: 'jsx',
@@ -150,6 +151,24 @@ function createElement({ node, style, useInlineStyles, key }) {
                 <span className="label__text">Show line numbers</span>
               </label>
             </div>
+
+            <div className="options__option options__option--wrap-long-lines">
+              <label htmlFor="wrapLongLines" className="option__label">
+                <input
+                  type="checkbox"
+                  className="option__checkbox"
+                  checked={this.state.wrapLongLines}
+                  onChange={() =>
+                    this.setState({
+                      wrapLongLines: !this.state.wrapLongLines
+                    })
+                  }
+                  id="wrapLongLines"
+                />
+
+                <span className="label__text">Wrap long lines</span>
+              </label>
+            </div>
           </aside>
 
           <article className="example__container">
@@ -166,6 +185,7 @@ function createElement({ node, style, useInlineStyles, key }) {
               style={this.state.styleSrc}
               showLineNumbers={this.state.showLineNumbers}
               wrapLines={true}
+              wrapLongLines={this.state.wrapLongLines}
               lineProps={lineNumber => ({
                 style: { display: 'block', cursor: 'pointer' },
                 onClick() {

--- a/demo/prism-async-light.js
+++ b/demo/prism-async-light.js
@@ -38,6 +38,8 @@ function createClassNameString(classNames) {
   return classNames.join(' ');
 }
 
+// this comment is here to demonstrate an extremely long line length, well beyond what you should probably allow in your own code, though sometimes you'll be highlighting code you can't refactor, which is unfortunate but should be handled gracefully
+
 function createChildren(style, useInlineStyles) {
   let childrenCount = 0;
   return children => {

--- a/demo/prism.js
+++ b/demo/prism.js
@@ -42,7 +42,8 @@ export default uniquePropHOC(["time", "seconds"])(Expire);
       selectedStyle: availableStyles[0],
       style: require(`../src/styles/prism/${availableStyles[0]}`).default,
       code: initialCodeString,
-      showLineNumbers: false
+      showLineNumbers: false,
+      wrapLongLines: false
     };
   }
   render() {
@@ -106,6 +107,24 @@ export default uniquePropHOC(["time", "seconds"])(Expire);
                 <span className="label__text">Show line numbers</span>
               </label>
             </div>
+
+            <div className="options__option options__option--wrap-long-lines">
+              <label htmlFor="wrapLongLines" className="option__label">
+                <input
+                  type="checkbox"
+                  className="option__checkbox"
+                  checked={this.state.wrapLongLines}
+                  onChange={() =>
+                    this.setState({
+                      wrapLongLines: !this.state.wrapLongLines
+                    })
+                  }
+                  id="wrapLongLines"
+                />
+
+                <span className="label__text">Wrap long lines</span>
+              </label>
+            </div>
           </aside>
 
           <article className="example__container">
@@ -121,6 +140,7 @@ export default uniquePropHOC(["time", "seconds"])(Expire);
             <SyntaxHighlighter
               style={this.state.style}
               showLineNumbers={this.state.showLineNumbers}
+              wrapLongLines={this.state.wrapLongLines}
               language={this.state.language}
             >
               {this.state.code}

--- a/demo/prism.js
+++ b/demo/prism.js
@@ -14,6 +14,8 @@ class Component extends React.Component {
     const initialCodeString = `import React from "react";
 import uniquePropHOC from "./lib/unique-prop-hoc";
 
+// this comment is here to demonstrate an extremely long line length, well beyond what you should probably allow in your own code, though sometimes you'll be highlighting code you can't refactor, which is unfortunate but should be handled gracefully
+
 class Expire extends React.Component {
     constructor(props) {
         super(props);
@@ -31,7 +33,10 @@ class Expire extends React.Component {
     }
 }
 
-export default uniquePropHOC(["time", "seconds"])(Expire);`;
+export default uniquePropHOC(["time", "seconds"])(Expire);
+`;
+
+
     this.state = {
       language: 'javascript',
       selectedStyle: availableStyles[0],

--- a/demo/virtualized.js
+++ b/demo/virtualized.js
@@ -1897,7 +1897,8 @@ function createElement({ node, style, useInlineStyles, key }) {
       selectedStyle: availableStyles[0],
       style: require(`../src/styles/hljs/${availableStyles[0]}`).default,
       code: initialCodeString,
-      showLineNumbers: false
+      showLineNumbers: false,
+      wrapLongLines: false
     };
   }
   render() {
@@ -1947,6 +1948,24 @@ function createElement({ node, style, useInlineStyles, key }) {
                 <span className="label__text">Show line numbers</span>
               </label>
             </div>
+
+            <div className="options__option options__option--wrap-long-lines">
+              <label htmlFor="wrapLongLines" className="option__label">
+                <input
+                  type="checkbox"
+                  className="option__checkbox"
+                  checked={this.state.wrapLongLines}
+                  onChange={() =>
+                    this.setState({
+                      wrapLongLines: !this.state.wrapLongLines
+                    })
+                  }
+                  id="wrapLongLines"
+                />
+
+                <span className="label__text">Wrap long lines</span>
+              </label>
+            </div>
           </aside>
 
           <article className="example__container">
@@ -1955,6 +1974,7 @@ function createElement({ node, style, useInlineStyles, key }) {
               style={this.state.style}
               showLineNumbers={this.state.showLineNumbers}
               showInlineLineNumbers={true}
+              wrapLongLines={this.state.wrapLongLines}
               renderer={virtualizedRenderer({
                 rowHeight: 20
               })}

--- a/demo/virtualized.js
+++ b/demo/virtualized.js
@@ -20,6 +20,8 @@ function createClassNameString(classNames) {
   return classNames.join(' ');
 }
 
+// this comment is here to demonstrate an extremely long line length, well beyond what you should probably allow in your own code, though sometimes you'll be highlighting code you can't refactor, which is unfortunate but should be handled gracefully
+
 function createChildren(style, useInlineStyles) {
   let childrenCount = 0;
   return children => {

--- a/demo/virtualized.js
+++ b/demo/virtualized.js
@@ -1897,8 +1897,7 @@ function createElement({ node, style, useInlineStyles, key }) {
       selectedStyle: availableStyles[0],
       style: require(`../src/styles/hljs/${availableStyles[0]}`).default,
       code: initialCodeString,
-      showLineNumbers: false,
-      wrapLongLines: false
+      showLineNumbers: false
     };
   }
   render() {
@@ -1948,24 +1947,6 @@ function createElement({ node, style, useInlineStyles, key }) {
                 <span className="label__text">Show line numbers</span>
               </label>
             </div>
-
-            <div className="options__option options__option--wrap-long-lines">
-              <label htmlFor="wrapLongLines" className="option__label">
-                <input
-                  type="checkbox"
-                  className="option__checkbox"
-                  checked={this.state.wrapLongLines}
-                  onChange={() =>
-                    this.setState({
-                      wrapLongLines: !this.state.wrapLongLines
-                    })
-                  }
-                  id="wrapLongLines"
-                />
-
-                <span className="label__text">Wrap long lines</span>
-              </label>
-            </div>
           </aside>
 
           <article className="example__container">
@@ -1974,7 +1955,6 @@ function createElement({ node, style, useInlineStyles, key }) {
               style={this.state.style}
               showLineNumbers={this.state.showLineNumbers}
               showInlineLineNumbers={true}
-              wrapLongLines={this.state.wrapLongLines}
               renderer={virtualizedRenderer({
                 rowHeight: 20
               })}

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -319,7 +319,7 @@ export default function(defaultAstGenerator, defaultStyle) {
     startingLineNumber = 1,
     lineNumberContainerStyle,
     lineNumberStyle = {},
-    wrapLines,
+    wrapLines = true,
     wrapLongLines = false,
     lineProps = {},
     renderer,

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -118,9 +118,7 @@ function createLineElement({
   }
 
   if (wrapLongLines & showLineNumbers) {
-    properties.style
-      ? (properties.style['display'] = 'flex')
-      : (properties.style = { display: 'flex' });
+    properties.style = { ...properties.style, display: 'flex' };
   }
 
   return {
@@ -409,13 +407,9 @@ export default function(defaultAstGenerator, defaultStyle) {
     );
 
     if (wrapLongLines) {
-      codeTagProps.style
-        ? (codeTagProps.style.whiteSpace = 'pre-wrap')
-        : (codeTagProps.style = { whiteSpace: 'pre-wrap' });
+      codeTagProps.style = { ...codeTagProps.style, whiteSpace: 'pre-wrap' };
     } else {
-      codeTagProps.style
-        ? (codeTagProps.style.whiteSpace = 'pre')
-        : (codeTagProps.style = { whiteSpace: 'pre' });
+      codeTagProps.style = { ...codeTagProps.style, whiteSpace: 'pre' };
     }
 
     return (

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -315,7 +315,7 @@ export default function(defaultAstGenerator, defaultStyle) {
     },
     useInlineStyles = true,
     showLineNumbers = false,
-    showInlineLineNumbers = false,
+    showInlineLineNumbers = true,
     startingLineNumber = 1,
     lineNumberContainerStyle,
     lineNumberStyle = {},

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -330,7 +330,7 @@ export default function(defaultAstGenerator, defaultStyle) {
     startingLineNumber = 1,
     lineNumberContainerStyle,
     lineNumberStyle = {},
-    wrapLines = true,
+    wrapLines,
     wrapLongLines = false,
     lineProps = {},
     renderer,
@@ -379,7 +379,8 @@ export default function(defaultAstGenerator, defaultStyle) {
      * some custom renderers rely on individual row elements so we need to turn wrapLines on
      * if renderer is provided and wrapLines is undefined
      */
-    wrapLines = renderer && wrapLines === undefined ? true : wrapLines;
+    wrapLines =
+      (renderer || wrapLongLines) && wrapLines === undefined ? true : wrapLines;
     renderer = renderer || defaultRenderer;
     const defaultCodeValue = [{ type: 'text', value: code }];
     const codeTree = getCodeTree({

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -399,6 +399,10 @@ export default function(defaultAstGenerator, defaultStyle) {
       codeTagProps.style
         ? (codeTagProps.style.whiteSpace = 'pre-wrap')
         : (codeTagProps.style = { whiteSpace: 'pre-wrap' });
+    } else {
+      codeTagProps.style
+        ? (codeTagProps.style.whiteSpace = 'pre')
+        : (codeTagProps.style = { whiteSpace: 'pre' });
     }
 
     return (

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -320,6 +320,7 @@ export default function(defaultAstGenerator, defaultStyle) {
     lineNumberContainerStyle,
     lineNumberStyle = {},
     wrapLines,
+    wrapLongLines = false,
     lineProps = {},
     renderer,
     PreTag = 'pre',
@@ -393,6 +394,12 @@ export default function(defaultAstGenerator, defaultStyle) {
       largestLineNumber,
       lineNumberStyle
     );
+
+    if (wrapLongLines) {
+      codeTagProps.style
+        ? (codeTagProps.style.whiteSpace = 'pre-wrap')
+        : (codeTagProps.style = { whiteSpace: 'pre-wrap' });
+    }
 
     return (
       <PreTag {...preProps}>

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -374,11 +374,12 @@ export default function(defaultAstGenerator, defaultStyle) {
     }
 
     /*
-     * some custom renderers rely on individual row elements so we need to turn wrapLines on
-     * if renderer is provided and wrapLines is undefined
+     * Some custom renderers rely on individual row elements so we need to turn wrapLines on
+     * if renderer is provided and wrapLines is undefined.
      */
-    wrapLines =
-      (renderer || wrapLongLines) && wrapLines === undefined ? true : wrapLines;
+    if ((wrapLines === undefined && renderer) || wrapLongLines)
+      wrapLines = true;
+
     renderer = renderer || defaultRenderer;
     const defaultCodeValue = [{ type: 'text', value: code }];
     const codeTree = getCodeTree({

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -100,7 +100,9 @@ function createLineElement({
   largestLineNumber,
   showInlineLineNumbers,
   lineProps = {},
-  className = []
+  className = [],
+  showLineNumbers,
+  wrapLongLines
 }) {
   const properties =
     typeof lineProps === 'function' ? lineProps(lineNumber) : lineProps;
@@ -113,6 +115,12 @@ function createLineElement({
       largestLineNumber
     );
     children.unshift(getInlineLineNumber(lineNumber, inlineLineNumberStyle));
+  }
+
+  if (wrapLongLines & showLineNumbers) {
+    properties.style
+      ? (properties.style['display'] = 'flex')
+      : (properties.style = { display: 'flex' });
   }
 
   return {
@@ -149,7 +157,8 @@ function processLines(
   showInlineLineNumbers,
   startingLineNumber,
   largestLineNumber,
-  lineNumberStyle
+  lineNumberStyle,
+  wrapLongLines
 ) {
   const tree = flattenCodeTree(codeTree.value);
   const newTree = [];
@@ -164,7 +173,9 @@ function processLines(
       largestLineNumber,
       showInlineLineNumbers,
       lineProps,
-      className
+      className,
+      showLineNumbers,
+      wrapLongLines
     });
   }
 
@@ -392,7 +403,8 @@ export default function(defaultAstGenerator, defaultStyle) {
       showInlineLineNumbers,
       startingLineNumber,
       largestLineNumber,
-      lineNumberStyle
+      lineNumberStyle,
+      wrapLongLines
     );
 
     if (wrapLongLines) {


### PR DESCRIPTION
Fixes #235 and introduces a few API & styling changes along the way.

1. New prop: `wrapLongLines`
2. New default prop value: `showInlineLineNumbers = true`
3. Explicit white-space styling on `<code>` tag

## 1. New prop: "wrapLongLines"

`wrapLongLines` takes care of adding `white-space: pre-wrap` styling to the `<code>` tag: no need to do this yourself via CSS or `codeTagProps` anymore.

There are a few potential consequences of this new prop.

### Containing elements around each line

If you've set `wrapLongLines={true}`, React Syntax Highlighter will wrap each line of code in its own `<span>`, just as if you'd explicitly set `wrapLines={true}`.

This could be a breaking change for anyone who is currently:
- manually setting `white-space: pre-wrap` on their `<code>` element
- has `wrapLines={false}` or is using Prism, which defaults to _not_ creating containing elements around each line's elements
- is theming with CSS direct-descendant selectors that would break if there was a containing element around each line's elements

> `wrapLines` is another awkward prop name that should eventually be changed, because it affects containing elements, not text-wrapping. `wrapLongLines` now actually does what some people mistakenly thought `wrapLines` would do.

### display: flex to provide long-line wrapping that doesn't flow into the line number area

If you're using `wrapLongLines={true}` and are showing line numbers (`showLineNumbers={true}`), we'll now style each line element with `display: flex`.

This overrides the `display: block` styling that most themes apply to each line.

**Probably won't be a noticeable change for most users, but if you see any unexpected `line-height` changes with this change, that's probably the cause.**


## 2. New default prop value (potentially breaking change)
`showInlineLineNumbers = true`

The old default for line numbering (`showLineNumbers` + `showInlineLineNumbers = false`) created a separate `<code>` element containing all line numbers.

This was problematic when using a virtualized renderer or when applying `white-space: pre-wrap` to the code area. Since having line numbers inside each line element is advantageous in several cases, I think it should become the default method of rendering line numbers.

> `showInlineLineNumbers` is confusingly named, I admit: it should have been "preferInlineNumbering" or "putLineNumbersInline", since `showLineNumbers` is still the prop that controls whether or not line numbers are visible at all.



## 3. Explicit white-space styling on `<code>` tag (potentially breaking change)

In order to set `white-space: pre-wrap` when `wrapLongLines={true}`, RSH now explicitly sets `white-space: pre` when in the default state of `wrapLongLines={false}`. If you've manually applied `white-space: pre-wrap` via `codeTagProps` or your theme CSS, this might override your intended styling.

The workaround here is to migrate to using the new `wrapLongLines={true}` prop, which will provide the `pre-wrap` styling for you.

