### PR TITLE
Show line numbers only when `showLineNumbers == true`

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -178,7 +178,7 @@ function processLines(
   }
 
   function createUnwrappedLine(children, lineNumber) {
-    if (lineNumber && showInlineLineNumbers) {
+    if (showLineNumbers && lineNumber && showInlineLineNumbers) {
       const inlineLineNumberStyle = assembleLineNumberStyles(
         lineNumberStyle,
         lineNumber,


### PR DESCRIPTION
After updating to 14.0.0, I started seeing line numbers for code blocks of a single line even when `showLineNumbers` was unset. One potential [walkaround](https://github.com/AbhyudayaSharma/abhyudayasharma.github.io/commit/202be8ae24246543afc2762fa5eed521e71b2356) I found was to explicitly set `showInlineLineNumbers = false`. But this PR fixes the problem with unwrapped lines by only showing line numbers if `showLineNumbers == true`.

This is how I was using `SyntaxHighlighter`:

```typescript
<SyntaxHighlighter language={language || 'text'} style={darcula}>
  {this.props.value}
</SyntaxHighlighter>
```

Before:
![image](https://user-images.githubusercontent.com/11471599/94912430-4190a900-04c5-11eb-8425-0995150bf938.png)


After:
![image](https://user-images.githubusercontent.com/11471599/94911099-3c325f00-04c3-11eb-92d4-4a9c5cbf2510.png)

I think there exists a similar bug when `wrapLongLines == true` but this PR does not fix that.
