### PR TITLE
Override default styles with styles from language

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -320,7 +320,10 @@ export default function(defaultAstGenerator, defaultStyle) {
     customStyle = {},
     codeTagProps = {
       className: language ? `language-${language}` : undefined,
-      style: style['code[class*="language-"]']
+      style: {
+        ...style['code[class*="language-"]'],
+        ...style['code[class*="language-${language}"]'],
+      },
     },
     useInlineStyles = true,
     showLineNumbers = false,


### PR DESCRIPTION
The styles from `prism-themes@1.4.1` have been updated in #313 (thanks @simmerer!). And due to #305, they are using more nested token styles.

However, they are missing some default styling (eg. JavaScript code blocks should have `#9cdcfe` as the default color), which I have found to be a limitation of `react-syntax-highlighter`. The default styles for a theme are not being overridden by those by the current language. 

This pull request is a possible solution to that issue.