### PR TITLE
Add solidity language support for highlight.js

### DIFF
--- a/AVAILABLE_LANGUAGES_HLJS.MD
+++ b/AVAILABLE_LANGUAGES_HLJS.MD
@@ -160,6 +160,7 @@
 * smali
 * smalltalk
 * sml
+* solidity
 * sqf
 * sql
 * stan

--- a/package-lock.json
+++ b/package-lock.json
@@ -6782,6 +6782,11 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.1.tgz",
       "integrity": "sha512-b4L09127uVa+9vkMgPpdUQP78ickGbHEQTWeBrQFTJZ4/n2aihWOGS0ZoUqAwjVmfjhq/C76HRzkqwZhK4sBbg=="
     },
+    "highlightjs-solidity": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-1.0.18.tgz",
+      "integrity": "sha512-k15h0br4oCRT0F0jTRuZbimerVt5V4n0k25h7oWi0kVqlBNeXPbSr5ddw02/2ukJmYfB8jauFDmxSauJjwM7Eg=="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@babel/runtime": "^7.3.1",
     "highlight.js": "^10.1.1",
+    "highlightjs-solidity": "^1.0.18",
     "lowlight": "^1.14.0",
     "prismjs": "^1.21.0",
     "refractor": "^3.1.0"

--- a/src/languages/hljs/solidity.js
+++ b/src/languages/hljs/solidity.js
@@ -1,0 +1,2 @@
+import solidity from "highlightjs-solidity";
+export default solidity;


### PR DESCRIPTION
This PR adds language support for [Solidity](https://solidity.readthedocs.io/), a Ethereum Virtual Machine smart contract programming language. It's supported by Prism already; this PR adds support for highlight.js.

The package it refers to is `highlightjs-solidity`, a package that @haltman-at at our company [Truffle Suite](https://trufflesuite.com) has been maintaining. It seems the npmjs.com package still points to an outdated repo, but the [official repo](https://github.com/highlightjs/highlightjs-solidity) does live within the official `highlightjs` GitHub organization. It appears that going forward, the maintainers of `highlight.js` are preferring separate repos for new languages, which is why we need a new dependency in `package.json`.

I've also given access to my coworkers @kevinbluer and @haltman-at which may be able to help out too

I'm going OOO for the next couple weeks if there's any feedback here, but I'll respond when I get back. I checked the box that let's the maintainers edit my branch. Thanks for the consideration!