### PR TITLE
Prevent unwanted final line number when wrapLines = true

### DIFF
--- a/__tests__/__snapshots__/wrap-lines.js.snap
+++ b/__tests__/__snapshots__/wrap-lines.js.snap
@@ -2199,25 +2199,11 @@ exports[`SyntaxHighlighter renders java code correctly with wrapLines 1`] = `
     <span
       style={
         Object {
-          "backgroundColor": "",
-          "display": "",
+          "backgroundColor": "#A9DBB8",
+          "display": "block",
         }
       }
     >
-      <span
-        className="comment linenumber react-syntax-highlighter-line-number"
-        style={
-          Object {
-            "display": "inline-block",
-            "minWidth": "2em",
-            "paddingRight": "1em",
-            "textAlign": "right",
-            "userSelect": "none",
-          }
-        }
-      >
-        25
-      </span>
       <span
         style={Object {}}
       >

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -261,7 +261,7 @@ function processLines(
   if (lastLineBreakIndex !== tree.length - 1) {
     const children = tree.slice(lastLineBreakIndex + 1, tree.length);
     if (children && children.length) {
-      const lineNumber = newTree.length + startingLineNumber;
+      const lineNumber = showLineNumbers && newTree.length + startingLineNumber;
       const line = createLine(children, lineNumber);
       newTree.push(line);
     }


### PR DESCRIPTION
Fixes https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/321