### PR TITLE
Increase line number minwidth

### DIFF
--- a/__tests__/__snapshots__/line-numbers.js.snap
+++ b/__tests__/__snapshots__/line-numbers.js.snap
@@ -26,7 +26,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -87,7 +87,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -150,7 +150,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -215,7 +215,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -337,7 +337,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -354,7 +354,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -403,7 +403,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -420,7 +420,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -485,7 +485,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -534,7 +534,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -551,7 +551,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -592,7 +592,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -653,7 +653,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -716,7 +716,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -781,7 +781,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -903,7 +903,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -920,7 +920,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -969,7 +969,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -986,7 +986,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1051,7 +1051,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1100,7 +1100,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1117,7 +1117,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1158,7 +1158,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1219,7 +1219,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1282,7 +1282,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1347,7 +1347,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1469,7 +1469,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1486,7 +1486,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1535,7 +1535,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1552,7 +1552,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1617,7 +1617,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1666,7 +1666,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -1683,7 +1683,7 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
         Object {
           "color": "red",
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -2525,7 +2525,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -2585,7 +2585,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -2647,7 +2647,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -2711,7 +2711,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -2832,7 +2832,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -2848,7 +2848,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -2896,7 +2896,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -2912,7 +2912,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -2976,7 +2976,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3024,7 +3024,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3040,7 +3040,7 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3080,7 +3080,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3140,7 +3140,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3202,7 +3202,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3266,7 +3266,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3387,7 +3387,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3403,7 +3403,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3451,7 +3451,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3467,7 +3467,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3531,7 +3531,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3579,7 +3579,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",
@@ -3595,7 +3595,7 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       style={
         Object {
           "display": "inline-block",
-          "minWidth": "2em",
+          "minWidth": "2.25em",
           "paddingRight": "1em",
           "textAlign": "right",
           "userSelect": "none",

--- a/demo/build/demo-build.js
+++ b/demo/build/demo-build.js
@@ -76606,8 +76606,7 @@ function AllLineNumbers(_ref2) {
 }
 
 function getEmWidthOfNumber(num) {
-  var len = num.toString().length;
-  return "".concat(len, "em");
+  return "".concat(num.toString().length, ".25em");
 }
 
 function getInlineLineNumber(lineNumber, inlineLineNumberStyle) {
@@ -76801,7 +76800,7 @@ function processLines(codeTree, wrapLines, lineProps, showLineNumbers, showInlin
     var children = tree.slice(lastLineBreakIndex + 1, tree.length);
 
     if (children && children.length) {
-      var lineNumber = newTree.length + startingLineNumber;
+      var lineNumber = showLineNumbers && newTree.length + startingLineNumber;
       var line = createLine(children, lineNumber);
       newTree.push(line);
     }

--- a/demo/build/diff-build.js
+++ b/demo/build/diff-build.js
@@ -76478,8 +76478,7 @@ function AllLineNumbers(_ref2) {
 }
 
 function getEmWidthOfNumber(num) {
-  var len = num.toString().length;
-  return "".concat(len, "em");
+  return "".concat(num.toString().length, ".25em");
 }
 
 function getInlineLineNumber(lineNumber, inlineLineNumberStyle) {
@@ -76673,7 +76672,7 @@ function processLines(codeTree, wrapLines, lineProps, showLineNumbers, showInlin
     var children = tree.slice(lastLineBreakIndex + 1, tree.length);
 
     if (children && children.length) {
-      var lineNumber = newTree.length + startingLineNumber;
+      var lineNumber = showLineNumbers && newTree.length + startingLineNumber;
       var line = createLine(children, lineNumber);
       newTree.push(line);
     }

--- a/demo/build/prism-build.js
+++ b/demo/build/prism-build.js
@@ -43454,8 +43454,7 @@ function AllLineNumbers(_ref2) {
 }
 
 function getEmWidthOfNumber(num) {
-  var len = num.toString().length;
-  return "".concat(len, "em");
+  return "".concat(num.toString().length, ".25em");
 }
 
 function getInlineLineNumber(lineNumber, inlineLineNumberStyle) {
@@ -43649,7 +43648,7 @@ function processLines(codeTree, wrapLines, lineProps, showLineNumbers, showInlin
     var children = tree.slice(lastLineBreakIndex + 1, tree.length);
 
     if (children && children.length) {
-      var lineNumber = newTree.length + startingLineNumber;
+      var lineNumber = showLineNumbers && newTree.length + startingLineNumber;
       var line = createLine(children, lineNumber);
       newTree.push(line);
     }

--- a/demo/build/prismAsyncLight-build.js
+++ b/demo/build/prismAsyncLight-build.js
@@ -43475,8 +43475,7 @@ function AllLineNumbers(_ref2) {
 }
 
 function getEmWidthOfNumber(num) {
-  var len = num.toString().length;
-  return "".concat(len, "em");
+  return "".concat(num.toString().length, ".25em");
 }
 
 function getInlineLineNumber(lineNumber, inlineLineNumberStyle) {
@@ -43670,7 +43669,7 @@ function processLines(codeTree, wrapLines, lineProps, showLineNumbers, showInlin
     var children = tree.slice(lastLineBreakIndex + 1, tree.length);
 
     if (children && children.length) {
-      var lineNumber = newTree.length + startingLineNumber;
+      var lineNumber = showLineNumbers && newTree.length + startingLineNumber;
       var line = createLine(children, lineNumber);
       newTree.push(line);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-syntax-highlighter",
-  "version": "15.3.1",
+  "version": "15.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -41,8 +41,7 @@ function AllLineNumbers({
 }
 
 function getEmWidthOfNumber(num) {
-  const len = num.toString().length;
-  return `${len}em`;
+  return `${num.toString().length}.25em`;
 }
 
 function getInlineLineNumber(lineNumber, inlineLineNumberStyle) {


### PR DESCRIPTION
Line numbers were given a min width of <number of digits in largest line number>`em`, but that wasn't quite enough. Added `.25em` to the assigned `min-width`, which should keep consistent alignment for all line-numbered code.

Fixes https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/340