### PR TITLE
Update highlight.js to v10.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "dependencies": {
     "@babel/runtime": "^7.3.1",
-    "highlight.js": "^10.1.1",
+    "highlight.js": "^10.4.1",
     "lowlight": "^1.17.0",
     "prismjs": "^1.22.0",
     "refractor": "^3.2.0"


### PR DESCRIPTION
Currently `highlight.js` 10.4.1 will be installed in `node_modules/lowlight/node_modules`. Adding this will make sure that it's installed in root `node_modules` so `react-syntax-highlighter` uses the correct version.

Fixes #343.