### PR TITLE
Optional custom renderer for line number

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,22 @@ I do realize that javascript styles are not for everyone, so you can optionally 
 - `wrapLongLines` - boolean to specify whether to style the `<code>` block with `white-space: pre-wrap` or `white-space: pre`. [Demo](https://react-syntax-highlighter.github.io/react-syntax-highlighter/demo/)
 - `lineProps` - props to be passed to the span wrapping each line if wrapLines is true. Can be either an object or a function that receives current line number as argument and returns props object.
 - `renderer` - an optional custom renderer for rendering lines of code. See <a href="https://github.com/conorhastings/react-syntax-highlighter-virtualized-renderer">here</a> for an example.
+- `lineNumberRenderer` an optional custom renderer for rendering line number. ({ number, style }) => JSX.Element, default renderer is
+
+```js
+function defaultLineNumberRenderer({ number, style }) {
+  return (
+    <span
+      key={`line-${number}`}
+      className="react-syntax-highlighter-line-number"
+      style={typeof style === 'function' ? style(number) : style}
+    >
+      {`${number}\n`}
+    </span>
+  );
+}
+```
+
 - `PreTag` - the element or custom react component to use in place of the default pre tag, the outermost tag of the component (useful for custom renderer not targeting DOM).
 - `CodeTag` - the element or custom react component to use in place of the default code tag, the second tag of the component tree (useful for custom renderer not targeting DOM).
 - `spread props` pass arbitrary props to pre tag wrapping code.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "dependencies": {
     "@babel/runtime": "^7.3.1",
+    "cross-env": "^7.0.3",
     "highlight.js": "^10.4.1",
     "lowlight": "^1.17.0",
     "prismjs": "^1.22.0",
@@ -60,8 +61,8 @@
   "scripts": {
     "dev": "webpack-dev-server --hot --inline",
     "build": "npm run build:cjs && npm run build:esm && webpack",
-    "build:cjs": "BABEL_ENV=cjs babel src --out-dir ./dist/cjs",
-    "build:esm": "BABEL_ENV=esm babel src --out-dir ./dist/esm",
+    "build:cjs": "cross-env BABEL_ENV=cjs babel src --out-dir ./dist/cjs",
+    "build:esm": "cross-env BABEL_ENV=esm babel src --out-dir ./dist/esm",
     "watch": "npm run build:esm -- --watch",
     "build-styles-hljs": "node ./scripts/build-stylesheets-highlightjs.js",
     "build-languages-hljs": "node ./scripts/build-languages-highlightjs.js",

--- a/src/create-element.js
+++ b/src/create-element.js
@@ -136,12 +136,14 @@ export function createChildren(stylesheet, useInlineStyles) {
   return children => {
     childrenCount += 1;
     return children.map((child, i) =>
-      createElement({
-        node: child,
-        stylesheet,
-        useInlineStyles,
-        key: `code-segment-${childrenCount}-${i}`
-      })
+      React.isValidElement(child)
+        ? child
+        : createElement({
+            node: child,
+            stylesheet,
+            useInlineStyles,
+            key: `code-segment-${childrenCount}-${i}`
+          })
     );
   };
 }


### PR DESCRIPTION
optional custom renderer for rendering line number could be used. Chanages:
1.  Amend createChildren to support JSX.Element node
2.  Append line number renderer in props
3.  Add brief desc for new prop lineNumberRenderer
4.  Add cross-env for building on Windows platform