### PR TITLE
Apply white-space inline style when astGenerator missing

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -366,6 +366,12 @@ export default function(defaultAstGenerator, defaultStyle) {
           style: Object.assign({}, customStyle)
         });
 
+    if (wrapLongLines) {
+      codeTagProps.style = { ...codeTagProps.style, whiteSpace: 'pre-wrap' };
+    } else {
+      codeTagProps.style = { ...codeTagProps.style, whiteSpace: 'pre' };
+    }
+
     if (!astGenerator) {
       return (
         <PreTag {...preProps}>
@@ -408,12 +414,6 @@ export default function(defaultAstGenerator, defaultStyle) {
       lineNumberStyle,
       wrapLongLines
     );
-
-    if (wrapLongLines) {
-      codeTagProps.style = { ...codeTagProps.style, whiteSpace: 'pre-wrap' };
-    } else {
-      codeTagProps.style = { ...codeTagProps.style, whiteSpace: 'pre' };
-    }
 
     return (
       <PreTag {...preProps}>


### PR DESCRIPTION
This fixes an SSR mismatch when using a non-async SyntaxHighlighter on the server
and an async SyntaxHighlighter on the client - the whiteSpace style will be present
regardless of which return statement we hit later in the function.

I'm not sure if such an SSR configuration is supported or recommended, but this patch
fixed the problem for me, seems innocent enough, and passed tests locally.

I could also fix it by passing `codeTagProps={{style: {whiteSpace: "pre"}}}` to my
`SyntaxHighlighter`