### PR TITLE
Avoid adding extra newline to end of code string

### DIFF
--- a/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
+++ b/__tests__/__snapshots__/code-style-passed-to-line-numbers.js.snap
@@ -476,7 +476,6 @@ exports[`SyntaxHighlighter component passes along code style to non-inline line 
     }
 
     
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/custom-code.js.snap
+++ b/__tests__/__snapshots__/custom-code.js.snap
@@ -395,7 +395,6 @@ exports[`SyntaxHighlighter component renders custom react component where code t
     }
 
     
-
   </section>
 </pre>
 `;
@@ -795,7 +794,6 @@ exports[`SyntaxHighlighter renders div where code tag is by default 1`] = `
     }
 
     
-
   </div>
 </pre>
 `;

--- a/__tests__/__snapshots__/custom-pre.js.snap
+++ b/__tests__/__snapshots__/custom-pre.js.snap
@@ -395,7 +395,6 @@ exports[`SyntaxHighlighter component renders custom react component where pre ta
     }
 
     
-
   </code>
 </p>
 `;
@@ -795,7 +794,6 @@ exports[`SyntaxHighlighter renders div where pre tag is by default 1`] = `
     }
 
     
-
   </code>
 </div>
 `;

--- a/__tests__/__snapshots__/light-async.js.snap
+++ b/__tests__/__snapshots__/light-async.js.snap
@@ -174,7 +174,6 @@ exports[`SyntaxHighlighter renders fortran highlighted text 1`] = `
                     END
 
                        
-
   </code>
 </pre>
 `;
@@ -273,7 +272,6 @@ exports[`SyntaxHighlighter renders javascript highlighted text 1`] = `
         }
 
     }
-
   </code>
 </pre>
 `;
@@ -1022,7 +1020,6 @@ exports[`SyntaxHighlighter renders text while language loads 1`] = `
       style={Object {}}
     >
                          
-
     </span>
   </code>
 </pre>
@@ -1514,7 +1511,6 @@ exports[`When the code split is loaded - SyntaxHighlighter renders jsx highlight
           }
 
       }
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/line-numbers.js.snap
+++ b/__tests__/__snapshots__/line-numbers.js.snap
@@ -561,7 +561,6 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function 1`] = `
       11
     </span>
     
-
   </code>
 </pre>
 `;
@@ -1127,7 +1126,6 @@ exports[`SyntaxHighlighter allows lineNumberStyle as function for inline line nu
       11
     </span>
     
-
   </code>
 </pre>
 `;
@@ -1693,7 +1691,6 @@ exports[`SyntaxHighlighter allows lineNumberStyle as object 1`] = `
       11
     </span>
     
-
   </code>
 </pre>
 `;
@@ -2094,7 +2091,6 @@ exports[`SyntaxHighlighter component does not render line numbers if showInlineN
     }
 
     
-
   </code>
 </pre>
 `;
@@ -2495,7 +2491,6 @@ exports[`SyntaxHighlighter component does not render line numbers if showLineNum
     }
 
     
-
   </code>
 </pre>
 `;
@@ -3050,7 +3045,6 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       11
     </span>
     
-
   </code>
 </pre>
 `;
@@ -3605,7 +3599,6 @@ exports[`SyntaxHighlighter component renders line numbers if showLineNumbers ===
       11
     </span>
     
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/multiline-comments.js.snap
+++ b/__tests__/__snapshots__/multiline-comments.js.snap
@@ -175,7 +175,6 @@ exports[`Syntaxhighliter correctly renders multi-line comments in arduino langua
     }
 
     
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/no-inline.js.snap
+++ b/__tests__/__snapshots__/no-inline.js.snap
@@ -297,7 +297,6 @@ exports[`SyntaxHighlighter component renders correctly without inline styles whe
     }
 
     
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/no-language.js.snap
+++ b/__tests__/__snapshots__/no-language.js.snap
@@ -395,7 +395,6 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
     }
 
     
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/prism-async-light.js.snap
+++ b/__tests__/__snapshots__/prism-async-light.js.snap
@@ -272,7 +272,6 @@ exports[`When the code split is loaded - SyntaxHighlighter renders python highli
             print "My sources say no"
 
                  
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/refractor.js.snap
+++ b/__tests__/__snapshots__/refractor.js.snap
@@ -875,7 +875,6 @@ exports[`SyntaxHighlighter component renders correctly with refractor instead of
 
     </span>
     
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/render.js.snap
+++ b/__tests__/__snapshots__/render.js.snap
@@ -396,7 +396,6 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
     }
 
     
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/text-language.js.snap
+++ b/__tests__/__snapshots__/text-language.js.snap
@@ -45,7 +45,6 @@ exports[`SyntaxHighlighter component renders monospace text when text is passed 
     }
 
     
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/unknown-language.js.snap
+++ b/__tests__/__snapshots__/unknown-language.js.snap
@@ -396,7 +396,6 @@ exports[`SyntaxHighlighter component renders correctly by falling back to highli
     }
 
     
-
   </code>
 </pre>
 `;

--- a/__tests__/__snapshots__/wrap-lines.js.snap
+++ b/__tests__/__snapshots__/wrap-lines.js.snap
@@ -483,7 +483,6 @@ exports[`SyntaxHighlighter allows lineProps as an object 1`] = `
       }
     >
       
-
     </span>
   </code>
 </pre>
@@ -972,7 +971,6 @@ exports[`SyntaxHighlighter allows lineProps as function 1`] = `
       }
     >
       
-
     </span>
   </code>
 </pre>
@@ -1417,7 +1415,6 @@ exports[`SyntaxHighlighter component renders correctly 1`] = `
       style={Object {}}
     >
       
-
     </span>
   </code>
 </pre>

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -224,15 +224,15 @@ function processLines(
             tree[index + 1] &&
             tree[index + 1].children &&
             tree[index + 1].children[0];
+          const lastLineInPreviousSpan = { type: 'text', value: `${text}` };
           if (stringChild) {
-            const lastLineInPreviousSpan = { type: 'text', value: `${text}` };
             const newElem = createLineElement({
               children: [lastLineInPreviousSpan],
               className: node.properties.className
             });
             tree.splice(index + 1, 0, newElem);
           } else {
-            const children = [newChild];
+            const children = [lastLineInPreviousSpan];
             const line = createLine(
               children,
               lineNumber,


### PR DESCRIPTION
I discovered another SSR mismatch after #361.  When `language={"text"}` and `astGenerator` is truthy, `processLines` will add an extra newline to the end of the code string.  When `astGenerator` is falsy, `code` is passed through untouched here: https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/efc3f7b7537d1729193b7a472067bcbe6cbecaf1/src/highlight.js#L369-L376 This causes a mismatch if you use e.g. `PrismLight` on the server and `PrismAsyncLight` on the client.

There may be a reason this existed that I don't understand - a lot of snapshots had to be updated.  But from my narrow use cases everything looks fine to me visually.