### PR TITLE
Fix Prism comment styling not applying to inline line numbers

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -51,6 +51,7 @@ function getInlineLineNumber(lineNumber, inlineLineNumberStyle) {
     properties: {
       key: `line-number--${lineNumber}`,
       className: [
+        'token',
         'comment',
         'linenumber',
         'react-syntax-highlighter-line-number'


### PR DESCRIPTION
Currently, the inline line number gets a CSS class of comment, presumably because it should be styled as a comment?

Unfortunately, this is not the case because the CSS selector for comment styling in Prism themes requires a `token` class as well (e.g. [the default Prism theme](https://github.com/PrismJS/prism/blob/e38986f9557bc850340a5d6ba824da9439b9977d/themes/prism.css#L69)). This change adds that class so that comment styling properly applies. 

This applies when `useInlineStyles` is set to false and PrismJS CSS is used. 