### PR TITLE
Switch selector, deletion, and meta color in vs.js to WCAG color cont…

### DIFF
--- a/src/styles/hljs/vs.js
+++ b/src/styles/hljs/vs.js
@@ -58,16 +58,16 @@ export default {
         "color": "#a31515"
     },
     "hljs-deletion": {
-        "color": "#2b91af"
+        "color": "#237891"
     },
     "hljs-selector-attr": {
-        "color": "#2b91af"
+        "color": "#237891"
     },
     "hljs-selector-pseudo": {
-        "color": "#2b91af"
+        "color": "#237891"
     },
     "hljs-meta": {
-        "color": "#2b91af"
+        "color": "#237891"
     },
     "hljs-doctag": {
         "color": "#808080"


### PR DESCRIPTION
His this is the PR related to issue with regards to a particular color in the vs,js file not meeting WCAG's minimum requirements. 

Here is the before and after with this PR applied:
Out of compliance (#2b91af):
![image](https://user-images.githubusercontent.com/6301646/111847050-4c00fc80-88c5-11eb-95c5-38e61d48942b.png)

In compliance (#237891):
![image](https://user-images.githubusercontent.com/6301646/111847146-7d79c800-88c5-11eb-9b00-3c522fc404c3.png)

Again I've found this color used in a few more spots including prism/vs.js and some demo docs. Let me know if you'd like them updated there as well. Feel free to close this if this isn't an issue and otherwise please don't hesitate to let me know if you'd prefer a different color replacement than the one I've chosen. Thanks for all the work you do here!