### PR TITLE
Fixes wrapLongLines + showLineNumbers with wrapped lines

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -117,7 +117,7 @@ function createLineElement({
   }
 
   if (wrapLongLines & showLineNumbers) {
-    properties.style = { ...properties.style, display: 'flex' };
+    properties.style = { ...properties.style, display: 'flex', flexWrap: 'wrap' };
   }
 
   return {
@@ -326,7 +326,7 @@ export default function(defaultAstGenerator, defaultStyle) {
     },
     useInlineStyles = true,
     showLineNumbers = false,
-    showInlineLineNumbers = true,
+    showInlineLineNumbers = false,
     startingLineNumber = 1,
     lineNumberContainerStyle,
     lineNumberStyle = {},


### PR DESCRIPTION
Fixed #376.

* Add `flexWrap: 'wrap'` for `display: 'wrap';
* Revert to `showInlineLineNumbers=false` as default.

Revert to `showInlineLineNumbers=false` as default doesn't seem to break `white-space: pre-wrap`. However, it may still break virtualized renderer.