### PR TITLE
Expose refractor alias function on prism light syntax highlighter

### DIFF
--- a/src/prism-light.js
+++ b/src/prism-light.js
@@ -5,4 +5,7 @@ const SyntaxHighlighter = highlight(refractor, {});
 SyntaxHighlighter.registerLanguage = (_, language) =>
   refractor.register(language);
 
+SyntaxHighlighter.alias = (name, aliases) =>
+  refractor.alias(name, aliases);
+
 export default SyntaxHighlighter;


### PR DESCRIPTION
This allows client applications to register aliases for languages without having to try and access refractor directly. Useful for aliasing languages under other acronyms.

```js
import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter'
import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript'

SyntaxHighlighter.registerLanguage('javascript', javascript)
SyntaxHighlighter.alias('javascript', 'js')
```