### PR TITLE
fix: Fix the increase in running time caused by using 'concat'

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -140,7 +140,7 @@ function flattenCodeTree(tree, className = [], newTree = []) {
       );
     } else if (node.children) {
       const classNames = className.concat(node.properties.className);
-      newTree = newTree.concat(flattenCodeTree(node.children, classNames));
+      flattenCodeTree(node.children, classNames).forEach(i => newTree.push(i));
     }
   }
   return newTree;


### PR DESCRIPTION
In the case of large files (2w lines), the code here will cause the JS execution time to be too long.

![image](https://user-images.githubusercontent.com/15180992/116689720-fef76680-a9ea-11eb-9025-65bf262ffd08.png)

Change to this way to use the experience will be much better (Same data)

![image](https://user-images.githubusercontent.com/15180992/116689455-b8a20780-a9ea-11eb-80f7-1457c411c92a.png)
