### PR TITLE
Added marmota.app to "Built With react-syntax-highlighter"

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ SyntaxHighlighter.supportedLanguages;
 - [Neumorphism](https://www.neumorphism.io) - CSS code generator for Soft UI/Neumorphism shadows
 - [grape-ui](https://www.grapeui.com) - Component library using styled-system and other open source components.
 - [✅ Good Arduino Code](https://goodarduinocode.com) - A curated library of Arduino Coding examples
-
+- [marmota.app](https://marmota.app) - A desktop app to create simple markdown presentations
+ 
 If your project uses react-syntax-highlighter please send a pr to add!
 
 ### License


### PR DESCRIPTION
marmota.app uses react-syntax-highlighter to highlight code on presentation slides. I created a custom renderer to be able to show [arrows](https://marmota.app/docs/editing/arrows/) in code blocks.