### PR TITLE
fix: largestLineNumber for unparsable texts

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -401,7 +401,12 @@ export default function(defaultAstGenerator, defaultStyle) {
     }
 
     // determine largest line number so that we can force minWidth on all linenumber elements
-    const largestLineNumber = codeTree.value.length + startingLineNumber;
+    let lineCount = codeTree.value.length;
+    if (lineCount === 1 && codeTree.value[0].type === 'text') {
+      // Since codeTree for an unparsable text (e.g. 'a\na\na') is [{ type: 'text', value: 'a\na\na' }]
+      lineCount = codeTree.value[0].value.split('\n').length;
+    }
+    const largestLineNumber = lineCount + startingLineNumber;
 
     const rows = processLines(
       codeTree,


### PR DESCRIPTION
The current implementation cannot calculate correct `largestLineNumber` for unparsable texts, e.g., `'a\na\na'` as follows.

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/436237/156206454-ce41928b-049d-4e39-b242-23a1ef871822.png">

This PR fixes the above issue and yields the following rendering.

![image](https://user-images.githubusercontent.com/436237/156206765-0193c885-7b2a-46ed-8591-c1fed06909f8.png)