### PR TITLE
Fix not being able to override styles when wrapLongLines is true

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -117,7 +117,7 @@ function createLineElement({
   }
 
   if (wrapLongLines & showLineNumbers) {
-    properties.style = { ...properties.style, display: 'flex' };
+    properties.style = { display: 'flex', ...properties.style };
   }
 
   return {
@@ -367,9 +367,9 @@ export default function(defaultAstGenerator, defaultStyle) {
         });
 
     if (wrapLongLines) {
-      codeTagProps.style = { ...codeTagProps.style, whiteSpace: 'pre-wrap' };
+      codeTagProps.style = { whiteSpace: 'pre-wrap', ...codeTagProps.style };
     } else {
-      codeTagProps.style = { ...codeTagProps.style, whiteSpace: 'pre' };
+      codeTagProps.style = { whiteSpace: 'pre', ...codeTagProps.style };
     }
 
     if (!astGenerator) {


### PR DESCRIPTION
I encountered a specific use case in which I still needed to be able to override `display: flex` when wrapLongLines and showLineNumbers are true. This PR fixes this without changing functionality.