### PR TITLE
fix: lowlight is a named import

### DIFF
--- a/src/light.js
+++ b/src/light.js
@@ -1,5 +1,5 @@
 import highlight from './highlight';
-import lowlight from 'lowlight/lib/core';
+import {lowlight} from 'lowlight/lib/core';
 
 const SyntaxHighlighter = highlight(lowlight, {});
 SyntaxHighlighter.registerLanguage = lowlight.registerLanguage;


### PR DESCRIPTION
Fixes the following error:

> No matching export in "node_modules/lowlight/lib/core.js" for import "default".


lowlight is not a default but a named export in the lowlight package