### PR TITLE
Fix bug with `wrapLines` that butchers highlighting

### DIFF
--- a/__tests__/__snapshots__/prism-async.js.snap
+++ b/__tests__/__snapshots__/prism-async.js.snap
@@ -1,5 +1,498 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Prism SyntaxHighlighter renders template strings and JSX correctly 1`] = `
+<pre
+  style={
+    Object {
+      "MozHyphens": "none",
+      "MozTabSize": "4",
+      "OTabSize": "4",
+      "WebkitHyphens": "none",
+      "background": "#f5f2f0",
+      "color": "black",
+      "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+      "fontSize": "1em",
+      "hyphens": "none",
+      "lineHeight": "1.5",
+      "margin": ".5em 0",
+      "msHyphens": "none",
+      "overflow": "auto",
+      "padding": "1em",
+      "tabSize": "4",
+      "textAlign": "left",
+      "textShadow": "0 1px white",
+      "whiteSpace": "pre",
+      "wordBreak": "normal",
+      "wordSpacing": "normal",
+      "wordWrap": "normal",
+    }
+  }
+>
+  <code
+    className="language-jsx"
+    style={
+      Object {
+        "MozHyphens": "none",
+        "MozTabSize": "4",
+        "OTabSize": "4",
+        "WebkitHyphens": "none",
+        "background": "none",
+        "color": "black",
+        "fontFamily": "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
+        "fontSize": "1em",
+        "hyphens": "none",
+        "lineHeight": "1.5",
+        "msHyphens": "none",
+        "tabSize": "4",
+        "textAlign": "left",
+        "textShadow": "0 1px white",
+        "whiteSpace": "pre",
+        "wordBreak": "normal",
+        "wordSpacing": "normal",
+        "wordWrap": "normal",
+      }
+    }
+  >
+    <span
+      className="token module"
+      style={
+        Object {
+          "color": "#07a",
+        }
+      }
+    >
+      import
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token imports maybe-class-name"
+      style={Object {}}
+    >
+      React
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token module"
+      style={
+        Object {
+          "color": "#07a",
+        }
+      }
+    >
+      from
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#690",
+        }
+      }
+    >
+      "react"
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      ;
+    </span>
+    <span
+      style={Object {}}
+    >
+      
+
+    </span>
+    
+
+    <span
+      style={Object {}}
+    >
+      
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#07a",
+        }
+      }
+    >
+      const
+    </span>
+    <span
+      style={Object {}}
+    >
+       x 
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "background": "hsla(0, 0%, 100%, .5)",
+          "color": "#9a6e3a",
+        }
+      }
+    >
+      =
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token template-string template-punctuation"
+      style={
+        Object {
+          "color": "#690",
+        }
+      }
+    >
+      \`
+    </span>
+    <span
+      className="token template-string"
+      style={
+        Object {
+          "color": "#690",
+        }
+      }
+    >
+      
+
+    </span>
+    <span
+      className="token template-string"
+      style={
+        Object {
+          "color": "#690",
+        }
+      }
+    >
+      template string.
+
+    </span>
+    <span
+      className="token template-string"
+      style={
+        Object {
+          "color": "#690",
+        }
+      }
+    >
+      
+    </span>
+    <span
+      className="token template-string template-punctuation"
+      style={
+        Object {
+          "color": "#690",
+        }
+      }
+    >
+      \`
+    </span>
+    <span
+      style={Object {}}
+    >
+      
+
+    </span>
+    
+
+    <span
+      style={Object {}}
+    >
+      
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#07a",
+        }
+      }
+    >
+      const
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token function-variable"
+      style={
+        Object {
+          "color": "#DD4A68",
+        }
+      }
+    >
+      y
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "background": "hsla(0, 0%, 100%, .5)",
+          "color": "#9a6e3a",
+        }
+      }
+    >
+      =
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      (
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      )
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token arrow"
+      style={
+        Object {
+          "background": "hsla(0, 0%, 100%, .5)",
+          "color": "#9a6e3a",
+        }
+      }
+    >
+      =&gt;
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      {
+    </span>
+    <span
+      style={Object {}}
+    >
+      
+
+    </span>
+    <span
+      style={Object {}}
+    >
+        
+    </span>
+    <span
+      className="token control-flow"
+      style={
+        Object {
+          "color": "#07a",
+        }
+      }
+    >
+      return
+    </span>
+    <span
+      style={Object {}}
+    >
+       
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      (
+    </span>
+    <span
+      style={Object {}}
+    >
+      
+
+    </span>
+    <span
+      style={Object {}}
+    >
+          
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      &lt;
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#905",
+        }
+      }
+    >
+      div
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      &gt;
+    </span>
+    <span
+      className="token plain-text"
+      style={Object {}}
+    >
+      
+
+    </span>
+    <span
+      className="token plain-text"
+      style={Object {}}
+    >
+            jsx
+
+    </span>
+    <span
+      className="token plain-text"
+      style={Object {}}
+    >
+          
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      &lt;/
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#905",
+        }
+      }
+    >
+      div
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      &gt;
+    </span>
+    <span
+      style={Object {}}
+    >
+      
+
+    </span>
+    <span
+      style={Object {}}
+    >
+        
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      )
+    </span>
+    <span
+      style={Object {}}
+    >
+      
+
+    </span>
+    <span
+      style={Object {}}
+    >
+      
+    </span>
+    <span
+      className="token"
+      style={
+        Object {
+          "color": "#999",
+        }
+      }
+    >
+      }
+    </span>
+  </code>
+</pre>
+`;
+
 exports[`SyntaxHighlighter renders jsx highlighted text 1`] = `
 <pre
   style={

--- a/__tests__/__snapshots__/wrap-lines.js.snap
+++ b/__tests__/__snapshots__/wrap-lines.js.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Prism SyntaxHighlighter renders JSX code correctly with wrapLines 1`] = `
+<pre
+  style={
+    Object {
+      "backgroundColor": "#fff",
+    }
+  }
+>
+  <code
+    className="language-jsx"
+    style={
+      Object {
+        "whiteSpace": "pre",
+      }
+    }
+  >
+    
+import React from "react";
+
+const x = \`
+template string.
+\`
+
+const y = () =&gt; {
+  return (
+    &lt;div&gt;
+      jsx
+    &lt;/div&gt;
+  )
+}
+
+  </code>
+</pre>
+`;
+
 exports[`SyntaxHighlighter allows lineProps as an object 1`] = `
 <pre
   style={

--- a/__tests__/prism-async.js
+++ b/__tests__/prism-async.js
@@ -74,3 +74,24 @@ test('When the code split is loaded - SyntaxHighlighter renders jsx highlighted 
 
   expect(tree).toMatchSnapshot();
 });
+
+test('Prism SyntaxHighlighter renders template strings and JSX correctly', () => {
+  const tree = renderer.create(
+    <SyntaxHighlighter language="jsx" style={prism}>
+      {`import React from "react";
+
+const x = \`
+template string.
+\`
+
+const y = () => {
+  return (
+    <div>
+      jsx
+    </div>
+  )
+}`}
+    </SyntaxHighlighter>
+  );
+  expect(tree).toMatchSnapshot();
+});

--- a/__tests__/wrap-lines.js
+++ b/__tests__/wrap-lines.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import SyntaxHighlighter from '../src';
+import { PrismAsync as PrismSyntaxHighlighter } from '../src';
 
 const code = `const woah = fun => fun + 1;
 const dude = woah(2) + 3;
@@ -16,6 +17,22 @@ function itIs() {
 
 const javaCode =
   'package com.javatest;\n\npublic class BubbleSort {\n  /**\n   * Applies bubble sort to an array and returns whether the array was sorted correctly.\n   */\n  public boolean checkSort(int[] a) {\n    sort(a);\n\n    for (int i = 0; i < a.length - 1; i++) {\n      if (a[i] > a[i + 1]) {\n        return false;\n      }\n    }\n\n    return true;\n  }\n\n  /**\n   * Bubble sort an array, mutating the array (contains a bug).\n   */\n  public void sort(int [] a) {\n    int j;\n    boolean flag = true;\n    int temp;';
+
+const jsxCode = `
+import React from "react";
+
+const x = \`
+template string.
+\`
+
+const y = () => {
+  return (
+    <div>
+      jsx
+    </div>
+  )
+}
+`;
 
 test('SyntaxHighlighter component renders correctly', () => {
   const tree = renderer
@@ -80,6 +97,22 @@ test('SyntaxHighlighter renders java code correctly with wrapLines', () => {
     >
       {javaCode}
     </SyntaxHighlighter>
+  );
+  expect(tree).toMatchSnapshot();
+});
+
+test('Prism SyntaxHighlighter renders JSX code correctly with wrapLines', () => {
+  const tree = renderer.create(
+    <PrismSyntaxHighlighter
+      language="jsx"
+      wrapLines={true}
+      lineProps={{
+        style: { backgroundColor: 'red' },
+        className: 'test-line-class'
+      }}
+    >
+      {jsxCode}
+    </PrismSyntaxHighlighter>
   );
   expect(tree).toMatchSnapshot();
 });

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -101,11 +101,18 @@ function createLineElement({
   lineProps = {},
   className = [],
   showLineNumbers,
-  wrapLongLines
+  wrapLongLines,
+  wrapLines = false
 }) {
-  const properties =
-    typeof lineProps === 'function' ? lineProps(lineNumber) : lineProps;
-  properties['className'] = className;
+  const properties = wrapLines
+    ? {
+        ...(typeof lineProps === 'function' ? lineProps(lineNumber) : lineProps)
+      }
+    : {};
+
+  properties['className'] = properties['className']
+    ? [...properties['className'].trim().split(/\s+/), ...className]
+    : className;
 
   if (lineNumber && showInlineLineNumbers) {
     const inlineLineNumberStyle = assembleLineNumberStyles(
@@ -172,7 +179,8 @@ function processLines(
       lineProps,
       className,
       showLineNumbers,
-      wrapLongLines
+      wrapLongLines,
+      wrapLines
     });
   }
 


### PR DESCRIPTION
## The Problem

When highlighting in JSX or TSX and using `prism`,  template strings would sometimes fail to be highlighted correctly, as seen in the demo screenshot below.

![2024-09-16 at 18 20 40](https://github.com/user-attachments/assets/ec631d7e-ff14-40ec-a3fb-0916f47d3b87)

To reproduce, include any JSX node with multi-line text as well as a multi-line template string. You'll see that everything between the first and last lines of the template string is highlighted as `plaintext` instead of `string`.

This happens even though the demo for the underlying `refractor` package does not produce such an error.

![2024-09-16 at 18 26 36](https://github.com/user-attachments/assets/0931ce78-27b1-4190-8992-0f84bffb04db)

## The Cause

The code for `createLineElement` in `highlight.js` modified the `lineProps` variable directly without copying it. This leads to `lineProps` at times taking on the className value of the currently processed line, which can then lead to other lines being wrapped with those classes.

What happened in the example above is that when the plaintext inside the JSX is processed, `lineProps` is butchered and then overrides the previously emitted `string` classes for the template string.

This code also leads to odd behavior when `lineProps` is specified but `wrapLines` is not, with only some lines being affected by `lineProps` and others not, seemingly at random.

## The Fix

1. We shallow copy the `lineProps` object to prevent it from being butchered.
2. We only use the `lineProps` object when `wrapLines` is set to true, as otherwise (according to the README documentation) it has no effect.
3. We merge the `className` field of `lineProps` with the generated classes to ensure both are present in the final output.

## Testing

I have confirmed this fixes the issue above, while also preserving `wrapLines` functionality. Additionally, `lineProps` now has no effect on output when `wrapLines` is not specified.

![2024-09-16 at 18 30 04](https://github.com/user-attachments/assets/ba48cf83-5be2-4a73-81e5-8e03db9acaeb)
