### PR TITLE
fix line count error

### DIFF
--- a/src/highlight.js
+++ b/src/highlight.js
@@ -408,13 +408,9 @@ export default function(defaultAstGenerator, defaultStyle) {
       codeTree.value = defaultCodeValue;
     }
 
-    // determine largest line number so that we can force minWidth on all linenumber elements
-    let lineCount = codeTree.value.length;
-    if (lineCount === 1 && codeTree.value[0].type === 'text') {
-      // Since codeTree for an unparsable text (e.g. 'a\na\na') is [{ type: 'text', value: 'a\na\na' }]
-      lineCount = codeTree.value[0].value.split('\n').length;
-    }
-    const largestLineNumber = lineCount + startingLineNumber;
+    // pre-determine largest line number so that we can force minWidth on all linenumber elements
+    const lineBreakCount = code.match(/\n/g)?.length ?? 0;
+    const largestLineNumber = startingLineNumber + lineBreakCount;
 
     const rows = processLines(
       codeTree,


### PR DESCRIPTION
Fixes #582, and likely #434 too, but I'm not sure about the latter.

The issue comes from an incorrect line count calculation which either counts the number of child nodes of the root of the AST or the number of newlines in the first node if it is the only node and it is text. This works for parsers that happen to output one root-child node per line, but not for others. What we want is the number of newlines in the whole text. There is also an off-by-one in the original calculation for the largest line number.

![before](https://github.com/user-attachments/assets/d432f3d0-d6a5-4c28-b7b2-f39727d069fc)
![after](https://github.com/user-attachments/assets/8e9a9dc6-35c3-49ef-b41f-86e5039aa82b)

