### PR TITLE
removed languages unsupported by highlight.js

### DIFF
--- a/src/languages/hljs/cs.js
+++ b/src/languages/hljs/cs.js
@@ -1,2 +1,0 @@
-import cs from "highlight.js/lib/languages/cs";
-export default cs;

--- a/src/languages/hljs/nimrod.js
+++ b/src/languages/hljs/nimrod.js
@@ -1,2 +1,0 @@
-import nimrod from "highlight.js/lib/languages/nimrod";
-export default nimrod;

--- a/src/languages/hljs/tex.js
+++ b/src/languages/hljs/tex.js
@@ -1,2 +1,0 @@
-import tex from "highlight.js/lib/languages/tex";
-export default tex;


### PR DESCRIPTION
Removed these files:
- cs.js
- nimrod.js
- tex.js

These files are not present in hightlight.js and only causes errors.

Closes #585 