### PR TITLE
Bump Webpack to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
         "request": "^2.88.0",
         "style-loader": "^0.13.0",
         "to-camel-case": "^1.0.0",
-        "webpack": "^4.22.0",
-        "webpack-cli": "^3.1.2",
+        "webpack": "^5.98.0",
+        "webpack-cli": "^6.0.1",
         "webpack-dev-server": "^3.1.14"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "request": "^2.88.0",
     "style-loader": "^0.13.0",
     "to-camel-case": "^1.0.0",
-    "webpack": "^4.22.0",
-    "webpack-cli": "^3.1.2",
+    "webpack": "^5.98.0",
+    "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^3.1.14"
   },
   "peerDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = {
         loader: 'babel-loader',
         exclude: [/node_modules/]
       },
-      { test: /\.css$/, loader: 'style!css' }
+      { test: /\.css$/, use: ['style-loader', 'css-loader'] }
     ]
   },
   plugins: [


### PR DESCRIPTION
## Why are you doing this?

To enable current Webpack documentation to apply. [Webpack 5 was released in late 2020](https://webpack.js.org/blog/2020-10-10-webpack-5-release/).