### PR TITLE
Use Node 22 LTS (Jod)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: circleci/node:16
+    - image: circleci/node:22
 
 jobs:
   test:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
       token: d37b4f28-c0ae-4546-81c9-0487a264db20
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [22.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ MIT
 
 ### Contributing
 
-You'll need Node 16.x installed & active on your system to build this package.
+You'll need Node 22.x installed & active on your system to build this package.
 
 ```
 npm i

--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
       "pre-commit": "lint-staged"
     }
   },
+  "engines": {
+    "node": "^22.14.0"
+  },
   "lint-staged": {
     "*.{js,json,css,md}": [
       "prettier --write",


### PR DESCRIPTION
## Why are we doing this?

To keep this project up-to-date with the latest Node versions and easier to maintain.

## What does this change?

- **feat: specify Node version to 22 Jod (LTS)**
- **chore: align node version in CI**
- **docs: specify node 22 in README**
