### PR TITLE
fix: ESM missing `.js`

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,7 +12,10 @@ module.exports = {
       presets: [['@babel/env']]
     },
     esm: {
-      plugins: ['@babel/transform-runtime'],
+      plugins: [
+        '@babel/transform-runtime',
+        ['babel-plugin-add-import-extension', { extension: 'js' }]
+      ],
       presets: [
         [
           '@babel/env',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-syntax-highlighter",
-  "version": "16.0.0",
+  "version": "16.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-syntax-highlighter",
-      "version": "16.0.0",
+      "version": "16.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -29,6 +29,7 @@
         "@babel/preset-react": "^7.27.1",
         "babel-jest": "^26.1.0",
         "babel-loader": "^9.2.1",
+        "babel-plugin-add-import-extension": "^1.6.0",
         "babel-plugin-transform-dynamic-import": "^2.1.0",
         "chokidar": "^3.6.0",
         "cross-env": "^7.0.3",
@@ -128,6 +129,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -3497,6 +3499,19 @@
         "webpack": ">=5"
       }
     },
+    "node_modules/babel-plugin-add-import-extension": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-import-extension/-/babel-plugin-add-import-extension-1.6.0.tgz",
+      "integrity": "sha512-JVSQPMzNzN/S4wPRoKQ7+u8PlkV//BPUMnfWVbr63zcE+6yHdU2Mblz10Vf7qe+6Rmu4svF5jG7JxdcPi9VvKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0"
+      }
+    },
     "node_modules/babel-plugin-istanbul": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
@@ -3841,6 +3856,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -5636,6 +5652,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -10755,6 +10772,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11954,6 +11972,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13849,6 +13868,7 @@
       "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -13897,6 +13917,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -14154,6 +14175,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/preset-react": "^7.27.1",
     "babel-jest": "^26.1.0",
     "babel-loader": "^9.2.1",
+    "babel-plugin-add-import-extension": "^1.6.0",
     "babel-plugin-transform-dynamic-import": "^2.1.0",
     "chokidar": "^3.6.0",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
This PR fixing the issue #626 where I explain the problem of not having the `.js` in the imports in ESM